### PR TITLE
store synched motor info always

### DIFF
--- a/sim/state/motornode.ts
+++ b/sim/state/motornode.ts
@@ -15,7 +15,7 @@ namespace pxsim {
         private speedCmdValues: number[];
         private speedCmdTacho: number;
         private speedCmdTime: number;
-        private _synchedMotor: MotorNode; // non-null if master motor
+        private _synchedMotor: MotorNode; // non-null if synchronized
 
         constructor(port: number, large: boolean) {
             super(port);
@@ -50,6 +50,7 @@ namespace pxsim {
 
         clearSpeedCmd() {
             delete this.speedCmd;
+            delete this.speedCmdValues;
             delete this._synchedMotor;
         }
 
@@ -135,10 +136,10 @@ namespace pxsim {
                 }
                 case DAL.opOutputStepSync:
                 case DAL.opOutputTimeSync: {
-                    if (!this._synchedMotor) // handled in other motor code
+                    const otherMotor = this._synchedMotor;
+                    if (otherMotor.port < this.port) // handled in other motor code
                         break;
 
-                    const otherMotor = this._synchedMotor;
                     const speed = this.speedCmdValues[0];
                     const turnRatio = this.speedCmdValues[1];
                     const stepsOrTime = this.speedCmdValues[2];

--- a/sim/state/output.ts
+++ b/sim/state/output.ts
@@ -70,7 +70,7 @@ namespace pxsim {
                             for (const motor of motors) {
                                 const otherMotor = motors.filter(m => m.port != motor.port)[0];
                                 motor.setSyncCmd(
-                                    motor.port < otherMotor.port ? otherMotor : undefined,
+                                    otherMotor,
                                     cmd, [speed, turnRatio, stepsOrTime, brake]);
                             }
                             return 2;


### PR DESCRIPTION
It looks like we are leaking the multiple motor display.  The display should be removed when the motor are not in sync anymore.

Try 
```
motors.largeBC.steer(0, 50, 2, MoveUnit.Rotations)
loops.pause(500)
motors.largeAD.setSpeed(50)
loops.pause(500)
motors.largeBC.tank(0, 50, 2, MoveUnit.Rotations)
```