### PR TITLE
Remove synced motor label when no longer in sync

### DIFF
--- a/sim/visuals/nodes/largeMotorView.ts
+++ b/sim/visuals/nodes/largeMotorView.ts
@@ -19,7 +19,11 @@ namespace pxsim.visuals {
             const syncedMotor = motorState.getSynchedMotor();
             if ((syncedMotor || this.syncedMotor) && syncedMotor != this.syncedMotor) {
                 this.syncedMotor = syncedMotor;
-                this.showSyncedLabel(motorState, syncedMotor);
+                if (this.syncedMotor) {
+                    this.showSyncedLabel(motorState, syncedMotor);
+                } else if (this.syncedLabelG) {
+                    this.syncedLabelG.parentNode.removeChild(this.syncedLabelG);
+                }
             }
         }
 


### PR DESCRIPTION
Remove synced motor label when motors are no longer in sync. 

To test: 
```
motors.largeBC.steer(0, 50, 2, MoveUnit.Rotations)
loops.pause(500)
motors.largeAD.setSpeed(50)
loops.pause(500)
motors.largeBC.tank(0, 50, 2, MoveUnit.Rotations)
```
  