### PR TITLE
Fix pauseUntilLight

### DIFF
--- a/libs/color-sensor/_locales/color-sensor-strings.json
+++ b/libs/color-sensor/_locales/color-sensor-strings.json
@@ -18,7 +18,7 @@
   "sensors.ColorSensor.onColorDetected|block": "on %sensor|detected color %color",
   "sensors.ColorSensor.onLightChanged|block": "on %sensor|%mode|%condition",
   "sensors.ColorSensor.pauseForColor|block": "pause %sensor|for color %color",
-  "sensors.ColorSensor.pauseForLight|block": "pause %sensor|for %mode|light %condition",
+  "sensors.ColorSensor.pauseForLight|block": "pause %sensor|for %mode|%condition",
   "sensors.color1|block": "color 1",
   "sensors.color2|block": "color 2",
   "sensors.color3|block": "color 3",

--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -182,7 +182,7 @@ namespace sensors {
          * @param color the color to detect
          */
         //% help=sensors/color-sensor/pause-for-light
-        //% block="pause %sensor|for %mode|light %condition"
+        //% block="pause %sensor|for %mode|%condition"
         //% blockId=colorPauseForLight
         //% parts="colorsensor"
         //% blockNamespace=sensors


### PR DESCRIPTION
Remove unnecessary extra 'light' text in block pauseUntilLight
Old: 
<img width="481" alt="screen shot 2018-01-06 at 9 07 55 pm" src="https://user-images.githubusercontent.com/16690124/34646758-b28af638-f325-11e7-8fb2-e1cbda6981db.png">



New: 

<img width="424" alt="screen shot 2018-01-06 at 9 07 17 pm" src="https://user-images.githubusercontent.com/16690124/34646756-a1a6d5ee-f325-11e7-9343-c45918c17622.png">
