### PR TITLE
Sort field port values. Fixes #212

### DIFF
--- a/editor/field_ports.ts
+++ b/editor/field_ports.ts
@@ -24,6 +24,9 @@ export class FieldPorts extends Blockly.FieldDropdown implements Blockly.FieldCu
         this.width_ = parseInt(options.width) || 300;
     }
 
+    trimOptions_() {
+    }
+
     /**
      * Create a dropdown menu under the text.
      * @private
@@ -42,7 +45,8 @@ export class FieldPorts extends Blockly.FieldDropdown implements Blockly.FieldCu
         // Accessibility properties
         contentDiv.setAttribute('role', 'menu');
         contentDiv.setAttribute('aria-haspopup', 'true');
-        const options = this.getOptions();
+        let options = this.getOptions();
+        options = options.sort();
         for (let i = 0, option: any; option = options[i]; i++) {
             let content = (options[i] as any)[0]; // Human-readable text or image.
             const value = (options[i] as any)[1]; // Language-neutral value.


### PR DESCRIPTION
Don't trim options, always sort field port values even if they are not sorted under the hood.
<img width="398" alt="screen shot 2018-01-09 at 11 43 15 am" src="https://user-images.githubusercontent.com/16690124/34739799-505b9b84-f532-11e7-84f4-11871ed36542.png">
