### PR TITLE
removing group icons

### DIFF
--- a/libs/ev3/ns.ts
+++ b/libs/ev3/ns.ts
@@ -9,7 +9,6 @@ namespace brick {
 //% color="#C8509B" weight=95 icon="\uf10f"
 //% labelLineWidth=0
 //% groups='["Touch Sensor", "Color Sensor", "Ultrasonic Sensor", "Gyro Sensor", "Infrared Sensor", "Remote Infrared Beacon", "Threshold"]'
-//% groupIcons='["\uf101","\uf103","\uf102","","","\uf104"]'
 namespace sensors {
 }
 


### PR DESCRIPTION
The group icons seems more like a distraction and have rendering issues in Edge/Firefox. Removing until we can fix them.