### PR TITLE
motor blocks with optional args

### DIFF
--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -223,7 +223,7 @@ namespace motors {
          * @param value (optional) measured distance or rotation
          * @param unit (optional) unit of the value
          */
-        //% blockId=motorSetSpeed block="set %motor speed to %speed=motorSpeedPicker||for %value %unit"
+        //% blockId=motorSetSpeed block="set %motor speed to %speed=motorSpeedPicker|\\%||for %value %unit"
         //% weight=100 blockGap=8
         //% group="Move"
         //% expandableArgumentMode=toggle
@@ -496,7 +496,7 @@ namespace motors {
          * @param value (optional) move duration or rotation
          * @param unit (optional) unit of the value
          */
-        //% blockId=motorPairTank block="tank %motors %speedLeft=motorSpeedPicker %speedRight=motorSpeedPicker||for %value %unit"
+        //% blockId=motorPairTank block="tank %motors %speedLeft=motorSpeedPicker|\\% %speedRight=motorSpeedPicker|\\%||for %value %unit"
         //% weight=96 blockGap=8
         //% inlineInputMode=inline
         //% group="Move"
@@ -523,7 +523,7 @@ namespace motors {
          * @param value (optional) move duration or rotation
          * @param unit (optional) unit of the value
          */
-        //% blockId=motorPairSteer block="steer %chassis turn ratio %turnRatio=motorTurnRatioPicker speed %speed=motorSpeedPicker||for %value %unit"
+        //% blockId=motorPairSteer block="steer %chassis turn ratio %turnRatio=motorTurnRatioPicker speed %speed=motorSpeedPicker|\\%||for %value %unit"
         //% weight=95
         //% turnRatio.min=-200 turnRatio=200
         //% inlineInputMode=inline

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "webfonts-generator": "^0.4.0"
   },
   "dependencies": {
-    "pxt-common-packages": "0.18.1",
-    "pxt-core": "3.3.1"
+    "pxt-common-packages": "0.19.1",
+    "pxt-core": "3.4.1"
   },
   "scripts": {
     "test": "node node_modules/pxt-core/built/pxt.js travis"


### PR DESCRIPTION
Attempt at support the expandable blocks. Requires pxt update.
Issues:
- [x] display % character (don't know how to escape it)
- [x] invalid first argument of optional parameters
![image](https://user-images.githubusercontent.com/4175913/35653777-99313468-069e-11e8-9d3d-785a3a0a3258.png)
- [x] number fields are slight misaligned when dragging out of the toolbar (I can still repro this)
![image](https://user-images.githubusercontent.com/4175913/35653829-d232f4f4-069e-11e8-94e2-d9a2144de17e.png)
- [x] note picker is all white
![image](https://user-images.githubusercontent.com/4175913/35899625-48d0b802-0b82-11e8-9138-d6dc42ea0436.png)
