### PR TITLE
add infrared sensor in ev3 library

### DIFF
--- a/libs/ev3/pxt.json
+++ b/libs/ev3/pxt.json
@@ -14,6 +14,7 @@
         "touch-sensor": "file:../touch-sensor",
         "ultrasonic-sensor": "file:../ultrasonic-sensor",
         "gyro-sensor": "file:../gyro-sensor",
+        "infrared-sensor": "file:../infrared-sensor",
         "mood": "file:../mood"
     },
     "public": true


### PR DESCRIPTION
There is no simulator support yet for these components.