### PR TITLE
Fixed the dropdown for colors

### DIFF
--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -19,21 +19,21 @@ enum LightIntensityMode {
 }
 
 const enum ColorSensorColor {
-    //% block="none" blockIdentity=sensors.color
+    //% block="none"
     None,
-    //% block="black" blockIdentity=sensors.color
+    //% block="black"
     Black,
-    //% block="blue" blockIdentity=sensors.color
+    //% block="blue"
     Blue,
-    //% block="green" blockIdentity=sensors.color
+    //% block="green"
     Green,
-    //% block="yellow" blockIdentity=sensors.color
+    //% block="yellow"
     Yellow,
-    //% block="red" blockIdentity=sensors.color
+    //% block="red"
     Red,
-    //% block="white" blockIdentity=sensors.color
+    //% block="white"
     White,
-    //% block="brown" blockIdentity=sensors.color
+    //% block="brown"
     Brown,
 }
 


### PR DESCRIPTION
Couldn't do the color picker, because the only color picker we have produces a number instead of an enum (see chibi editor). This fixes the decompilation at least.