### PR TITLE
Remove social buttons in footer

### DIFF
--- a/docfiles/footer.html
+++ b/docfiles/footer.html
@@ -1,0 +1,17 @@
+<footer class="ui inverted accent vertical footer segment hideprint" aria-hidden="false">
+    <div class="ui center aligned container">
+        <div class="ui inverted section divider"></div>
+        <div class="ui container horizontal inverted small divided link list">
+            <!-- <a class="item" href="https://makecode.com/contact" target="_blank" rel="noopener">Contact Us</a> -->
+            <a class="item" href="https://makecode.com/privacy" target="_blank" rel="noopener">Privacy &amp; Cookies</a>
+            <a class="item" href="https://makecode.com/termsofuse" target="_blank" rel="noopener"> Terms Of Use</a>
+            <a class="item" href="https://makecode.com/trademarks" target="_blank" rel="noopener">Trademarks</a>
+            <div class="item">© 2018 Microsoft</div>
+            <!-- we need to force the browser to load this font -->
+            <div style='font-family: Icons; color: #010101;' aria-hidden="true">.</div>
+        </div>
+        <div class="ui container horizontal inverted small divided link list">
+            <a class="ui centered item" href="https://makecode.com/" title="Microsoft MakeCode" target="_blank" rel="noopener">Powered by Microsoft MakeCode</a>
+        </div>
+    </div>
+</footer>


### PR DESCRIPTION
Mostly testing if this works or not, but it appears Lego is not interested in having social buttons in the footer. 