### PR TITLE
Fix resizing of screen canvas

### DIFF
--- a/sim/visuals/board.ts
+++ b/sim/visuals/board.ts
@@ -504,12 +504,12 @@ namespace pxsim.visuals {
             const bBox = this.layoutView.getBrick().getScreenBBox();
             if (!bBox || bBox.width == 0) return;
 
-            const scale = (bBox.width - 4) / SCREEN_WIDTH;
-            this.screenScaledWidth = (bBox.width - 4);
-            this.screenScaledHeight = this.screenScaledWidth / SCREEN_WIDTH * SCREEN_HEIGHT;
+            const scale = (bBox.height - 2) / SCREEN_HEIGHT;
+            this.screenScaledHeight = (bBox.height - 2);
+            this.screenScaledWidth = this.screenScaledHeight / SCREEN_HEIGHT * SCREEN_WIDTH;
 
-            this.screenCanvas.style.top = `${bBox.top + 2}px`;
-            this.screenCanvas.style.left = `${bBox.left + 2}px`;
+            this.screenCanvas.style.top = `${bBox.top + 1}px`;
+            this.screenCanvas.style.left = `${bBox.left + ((bBox.width - this.screenScaledWidth) * 0.5)}px`;
             this.screenCanvas.width = this.screenScaledWidth;
             this.screenCanvas.height = this.screenScaledHeight;
 


### PR DESCRIPTION
Fix resizing of screen canvas to ensure it fits within the area in the ev3 svg.

Fixes https://github.com/Microsoft/pxt-ev3/issues/350

![screen shot 2018-03-08 at 2 32 57 pm](https://user-images.githubusercontent.com/16690124/37180424-c8f8eda2-22dd-11e8-8154-fceaa8c42de7.png)
