### PR TITLE
hiding the was pressed block

### DIFF
--- a/docs/coding/ignition.md
+++ b/docs/coding/ignition.md
@@ -22,7 +22,7 @@ Play some motor sounds if touch sensor `1` is pressed at the same moment when an
 
 ```blocks
 while (true) {
-    if (sensors.touch1.wasPressed() &&
+    if (sensors.touch1.isPressed() &&
         sensors.ultrasonic4.distance() < 10) {
         music.playSoundEffectUntilDone(sounds.mechanicalMotorStart)
         music.playSoundEffectUntilDone(sounds.mechanicalMotorIdle);
@@ -38,8 +38,8 @@ Play some motor sounds if touch sensor `1` is pressed when both the `enter` butt
 ```blocks
 while (true) {
     if (sensors.ultrasonic4.distance() < 10 &&
-        sensors.touch1.wasPressed() &&
-        brick.buttonEnter.wasPressed()) {
+        sensors.touch1.isPressed() &&
+        brick.buttonEnter.isPressed()) {
         music.playSoundEffectUntilDone(sounds.mechanicalMotorStart)
         music.playSoundEffectUntilDone(sounds.mechanicalMotorIdle);
     }

--- a/docs/examples/line-follower-pid.md
+++ b/docs/examples/line-follower-pid.md
@@ -14,7 +14,7 @@ v = sensors.color3.light(LightIntensityMode.Reflected)
 min = v
 max = v
 setpoint = v
-while (!(brick.buttonEnter.wasPressed())) {
+while (!(brick.buttonEnter.isPressed())) {
     brick.clearScreen()
     brick.showString("Move robot on terrain", 1)
     brick.showString("Press ENTER when done", 2)

--- a/docs/reference/brick.md
+++ b/docs/reference/brick.md
@@ -20,8 +20,8 @@ brick.buttonEnter.onEvent(ButtonEvent.Bumped, function () {
 });
 brick.buttonEnter.pauseUntil(ButtonEvent.Bumped);
 brick.buttonEnter.isPressed()
-brick.buttonEnter.wasPressed()
 brick.setStatusLight(StatusLight.Red);
+brick.buttonEnter.wasPressed()
 ```
 
 ## Other

--- a/docs/reference/brick/button/was-pressed.md
+++ b/docs/reference/brick/button/was-pressed.md
@@ -14,7 +14,7 @@ The fact that a button was pressed earlier is remembered. Once **was pressed** i
 
 Your @boardname@ has touch sensors that work like buttons. Instead of saying `enter` or `left` as the source button, use a touch sensor block with a sensor name like `touch 1`.
 
-```block
+```typescript
 if (sensors.touch1.wasPressed()) {
     console.log("Hey, I was pressed.");
 }
@@ -32,7 +32,7 @@ Read about [touch sensors](/reference/sensors/touch-sensor) and using them as to
 
 Set the brick light to green if the `right` button was pressed before the `left` button. If not, the brick light is turned off when the `left` button is pressed.
 
-```blocks
+```typescript
 brick.buttonLeft.onEvent(ButtonEvent.Bumped, function() {
     if (brick.buttonRight.wasPressed()) {
         brick.setStatusLight(StatusLight.Green)
@@ -45,6 +45,5 @@ brick.buttonLeft.onEvent(ButtonEvent.Bumped, function() {
 ## See also
 
 [is pressed](/reference/brick/button/is-pressed),
-[on event](/reference/brick/button/on-event)
-
+[on event](/reference/brick/button/on-event),
 [Touch sensors](/reference/sensors/touch-sensor)

--- a/docs/reference/sensors.md
+++ b/docs/reference/sensors.md
@@ -17,8 +17,8 @@ sensors.color(ColorSensorColor.Blue)
 ```cards
 sensors.touch1.onEvent(ButtonEvent.Pressed, function () {})
 sensors.touch1.pauseUntil(ButtonEvent.Pressed)
-sensors.touch1.wasPressed()
 sensors.touch1.isPressed()
+sensors.touch1.wasPressed()
 ```
 
 ## Gyro

--- a/libs/core/buttons.ts
+++ b/libs/core/buttons.ts
@@ -95,6 +95,7 @@ namespace brick {
         //% help=brick/button/was-pressed
         //% block="%button|was pressed"
         //% blockId=buttonWasPressed
+        //% blockHidden=true
         //% parts="brick"
         //% blockNamespace=brick
         //% weight=80

--- a/libs/infrared-sensor/docs/reference/sensors/beacon/was-pressed.md
+++ b/libs/infrared-sensor/docs/reference/sensors/beacon/was-pressed.md
@@ -26,7 +26,7 @@ In order to recognize a button event signalled from a remote beacon, an infrared
 
 If the beacon button ``top left`` was pressed, show a `green` status light. Otherwise, set the status light to `orange`.
 
-```blocks
+```typescript
 sensors.infrared1.setRemoteChannel(InfraredRemoteChannel.Ch0)
 forever(function () {
     if (sensors.remoteButtonTopLeft.wasPressed()) {

--- a/libs/infrared-sensor/ir.ts
+++ b/libs/infrared-sensor/ir.ts
@@ -101,6 +101,7 @@ namespace sensors {
         //% help=sensors/beacon/was-pressed
         //% block="**remote button** %button|was pressed"
         //% blockId=remotebuttonWasPressed
+        //% blockHidden=true
         //% parts="remote"
         //% blockNamespace=sensors
         //% weight=80

--- a/libs/touch-sensor/docs/reference/sensors/touch-sensor/was-pressed.md
+++ b/libs/touch-sensor/docs/reference/sensors/touch-sensor/was-pressed.md
@@ -16,7 +16,7 @@ If a touch sensor was pressed, then that event is remembered. Once you check if 
 
 If the touch sensor ``touch 1`` was pressed, show a `green` status light. Otherwise, set the status light to `orange`.
 
-```blocks
+```typescript
 forever(function () {
     if (sensors.touch1.wasPressed()) {
         brick.setStatusLight(StatusLight.Green)

--- a/libs/touch-sensor/touch.ts
+++ b/libs/touch-sensor/touch.ts
@@ -83,6 +83,7 @@ namespace sensors {
         //% help=sensors/touch-sensor/was-pressed
         //% block="**touch** %this|was pressed"
         //% blockId=touchWasPressed
+        //% blockHidden=true
         //% parts="touch"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"


### PR DESCRIPTION
https://github.com/Microsoft/pxt-ev3/issues/399

"was pressed" is hidden but block annotation are still there.