### PR TITLE
Fix sensor port default logic

### DIFF
--- a/editor/field_ports.ts
+++ b/editor/field_ports.ts
@@ -2,7 +2,7 @@
 /// <reference path="../node_modules/pxt-core/built/pxtblocks.d.ts"/>
 /// <reference path="../node_modules/pxt-core/built/pxtsim.d.ts"/>
 
-export interface FieldPortsOptions extends Blockly.FieldCustomDropdownOptions {
+export interface FieldPortsOptions extends pxtblockly.FieldImagesOptions {
     columns?: string;
     width?: string;
 }
@@ -11,7 +11,7 @@ export class FieldPorts extends pxtblockly.FieldImages implements Blockly.FieldC
     public isFieldCustom_ = true;
 
     constructor(text: string, options: FieldPortsOptions, validator?: Function) {
-        super(text, options, validator);
+        super(text, { sort: true, data: options.data }, validator);
 
         this.columns_ = parseInt(options.columns) || 4;
         this.width_ = parseInt(options.width) || 300;
@@ -22,11 +22,6 @@ export class FieldPorts extends pxtblockly.FieldImages implements Blockly.FieldC
     }
 
     trimOptions_() {
-    }
-
-    getOptions() {
-        const options = super.getOptions();
-        return options ? options.sort() : undefined;
     }
 
     protected buttonClick_ = function (e: any) {


### PR DESCRIPTION
The change to move FieldPorts to extend FieldImages in PXT broke the logic we had to show different sensor default inputs. (hack of ordering). 

In that change we were sorting the items in the list on start, but what we really want is to sort the items in the list only after they the defaults have been initialized. 
I've added an option in FieldImages to sort elements (when the editor is open, showEditor_). 
https://github.com/Microsoft/pxt/pull/4085

