### PR TITLE
More tutorial typos

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1,6 +1,6 @@
 # Lessons
 
-Learning activities for LEGO Mindstorms with MakeCode.
+Learning activities for @boardname@ with MakeCode.
 
 ## Motors and motion
 

--- a/docs/lessons/make-it-move-tutorial.md
+++ b/docs/lessons/make-it-move-tutorial.md
@@ -10,7 +10,7 @@ Your robot will:
 * Use at least one motor
 * Use NO wheels for locomotion
 
-![LECG Mindstorms brick with parts](/static/lessons/make-it-move/locomotion-no-wheels.jpg)
+![LEGO MINDSTORMS brick with parts](/static/lessons/make-it-move/locomotion-no-wheels.jpg)
 
 
 ## Construct @unplugged
@@ -25,7 +25,7 @@ The legs in the Walker Bot are designed to show how to change the rotary motion 
 
 Start by reading [these](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/ev3-dep/building%20instructions/walker-bot-bi-180fc24f9298e1dd6201099627d43903.pdf) instructions first.
  
-![LEGO Mindstorms Walker Bot](/static/lessons/make-it-move/walker-bot.jpg)
+![LEGO MINDSTORMS Walker Bot](/static/lessons/make-it-move/walker-bot.jpg)
 
  
 ## Program 1 @fullscreen

--- a/docs/lessons/make-it-move.md
+++ b/docs/lessons/make-it-move.md
@@ -10,7 +10,7 @@ Your robot will:
 * Use at least one motor
 * Use NO wheels for locomotion
 
-![LECG Mindstorms brick with parts](/static/lessons/make-it-move/locomotion-no-wheels.jpg)
+![LEGO MINDSTORMS brick with parts](/static/lessons/make-it-move/locomotion-no-wheels.jpg)
 
 ## Construct
 
@@ -24,7 +24,7 @@ The legs in the Walker Bot are designed to show how to change the rotary motion 
 
 Start by reading [these](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/ev3-dep/building%20instructions/walker-bot-bi-180fc24f9298e1dd6201099627d43903.pdf) instructions first.
  
-![LEGO Mindstorms Walker Bot](/static/lessons/make-it-move/walker-bot.jpg)
+![LEGO MINDSTORMS Walker Bot](/static/lessons/make-it-move/walker-bot.jpg)
 
  
 ## Program

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -7,13 +7,13 @@ Step by step guides to coding your @boardname@.
 ```codecard
 [{
   "name": "Wake Up!",
-  "description": "Show different moods on your @boardname@. Is it tired, sleepy, or awake?",
+  "description": "Show different moods on the screen. Is it tired, sleepy, or awake?",
   "cardType": "tutorial",
   "url":"/tutorials/wake-up",
   "imageUrl":"/static/tutorials/wake-up.png"
 }, {
   "name": "Make An Animation",
-  "description": "Create a custom animation for your @boardname@.",
+  "description": "Create a custom animation on your brick screen.",
   "cardType": "tutorial",
   "url":"/tutorials/make-an-animation",
   "imageUrl":"/static/tutorials/make-an-animation.png"
@@ -25,7 +25,7 @@ Step by step guides to coding your @boardname@.
   "imageUrl":"/static/tutorials/what-animal-am-i.png"
 }, {
   "name": "Music Brick",
-  "description": "Transform your @boardname@ into a musical instrument!",
+  "description": "Transform the brick into a musical instrument!",
   "cardType": "tutorial",
   "url":"/tutorials/mindstorms-music",
   "imageUrl":"/static/tutorials/mindstorms-music.png"

--- a/docs/tutorials/mindstorms-music.md
+++ b/docs/tutorials/mindstorms-music.md
@@ -23,7 +23,7 @@ In the ``||brick:show string||`` block, type the text ``"Press my buttons to mak
 brick.showString("Press my buttons to make music!", 1)
 ```
 
-# Step 3
+## Step 3
 
 Open the ``||brick:Brick||`` Toolbox drawer. From the **Buttons** section, drag out an ``||brick:on button||`` block onto the Workspace (you can put it anywhere).
 

--- a/docs/tutorials/touch-to-run.md
+++ b/docs/tutorials/touch-to-run.md
@@ -36,7 +36,7 @@ sensors.touch1.onEvent(ButtonEvent.Released, function () {
 
 ## Step 3
 
-Open the ``||motors:Motors||`` Toolbox drawer. Drag out a ``||motors:run||`` block onto the Workspace, and drop it into the ``||brick:on touch pressed||`` block.
+Open the ``||motors:Motors||`` Toolbox drawer. Drag out a ``||motors:run||`` block onto the Workspace, and drop it into the ``||sensors:on touch pressed||`` block.
 
 ```blocks
 sensors.touch1.onEvent(ButtonEvent.Pressed, function () {

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -2,9 +2,9 @@
     "id": "ev3",
     "platformid": "linux",
     "nickname": "lego",
-    "name": "LEGO Mindstorms EV3",
-    "title": "LEGO Mindstorms EV3 - Blocks / Javascript editor",
-    "description": "A Blocks / JavaScript code editor for the LEGO Mindstorms EV3.",
+    "name": "LEGO MINDSTORMS EV3",
+    "title": "LEGO MINDSTORMS EV3 - Blocks / Javascript editor",
+    "description": "A Blocks / JavaScript code editor for the LEGO MINDSTORMS EV3.",
     "corepkg": "ev3",
     "bundleddirs": [
         "libs/base",
@@ -97,7 +97,7 @@
         "termsOfUseUrl": "https://go.microsoft.com/fwlink/?LinkID=206977",
         "githubUrl": "https://github.com/Microsoft/pxt-ev3",
         "betaUrl": "https://makecode.legoeducation.com/about",
-        "boardName": "LEGO Mindstorms EV3 Brick",
+        "boardName": "LEGO MINDSTORMS EV3 Brick",
         "selectLanguage": true,
         "availableLocales": [
             "en"


### PR DESCRIPTION
More typos found by Chris:

- [x] Replace "Mindstorms" with "MINDSTORMS" in _pxtarget.json_, please check!
- [x] Remove ``@boardname@`` from gallery descriptions cuz they're not expanded.
- [x] Fix a block category style in _touch-to-run.md_.
- [x] Wrong section level in step 3 of _mindstorms-music.md_. Missed by tutorial runner.

Original comments from Chris:

```
This is what I could find:
 
General
 
We only spell MINDSTORMS with capital letters
 
Mindstorms Music
• A step in which we tell the user to drag in the “on button” block is missing
 
Touch to Run
• In the hint section, the highlighted “on touch pressed” appear to be the wrong color

Why do you use @boardname@ in Wake Up and Make An Animation?

Regards

Chris
```
