### PR TITLE
Always show motor value

### DIFF
--- a/sim/visuals/nodes/motorView.ts
+++ b/sim/visuals/nodes/motorView.ts
@@ -18,7 +18,6 @@ namespace pxsim.visuals {
             if (!motorState) return;
             const speed = motorState.getSpeed();
 
-            if (!speed) return;
             this.setMotorAngle(motorState.getAngle() % 360);
             this.setMotorLabel(speed);
         }
@@ -42,13 +41,8 @@ namespace pxsim.visuals {
                 this.motorLabelGroup = pxsim.svg.child(this.content, "g") as SVGGElement;
                 this.motorLabel = pxsim.svg.child(this.motorLabelGroup, "text", { 'text-anchor': 'middle', 'x': '0', 'y': '0', 'class': 'sim-text number inverted' }) as SVGTextElement;
             }
-            // If Motor speed is not 0
-            if (this.currentLabel) {
-                this.motorLabel.textContent = `${this.currentLabel}%`;
-                this.positionMotorLabel();
-            } else {
-                this.motorLabel.textContent = ``;
-            }
+            this.motorLabel.textContent = `${this.currentLabel}%`;
+            this.positionMotorLabel();
         }
 
         protected abstract positionMotorLabel(): void;


### PR DESCRIPTION
Always show the motor value regardless if it's 0.

![screen shot 2018-04-13 at 1 56 18 pm](https://user-images.githubusercontent.com/16690124/38757608-75a1a75a-3f22-11e8-935a-3fb0494e9cc9.png)

Fixes https://github.com/Microsoft/pxt-ev3/issues/499
