### PR TITLE
Use pxtsemantic

### DIFF
--- a/theme/style.less
+++ b/theme/style.less
@@ -1,5 +1,5 @@
 /* Import all components */
-@import 'semantic';
+@import 'pxtsemantic';
 @import 'pxt';
 @import 'themes/default/globals/site.variables';
 @import 'themes/pxt/globals/site.variables';


### PR DESCRIPTION
Use pxtsemantic which includes only the semantic components we use in PXT. 

This should be the default in all targets. 

733kb -> 686kb