### PR TITLE
Changes accompanying the new blockly toolbox

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -162,7 +162,11 @@
             "variables": "\uf111",
             "text": "\uf110",
             "functions": "\uf108",
-            "arrays": "\uf109"
+            "arrays": "\uf109",
+            "search": "\uf11a",
+            "addpackage": "\uf105",
+            "advancedcollapsed": "\uf113",
+            "advancedexpanded": "\uf114"
         },
         "monacoColors": {
             "editor.background": "#f9f9f9"

--- a/theme/blockly-toolbox.less
+++ b/theme/blockly-toolbox.less
@@ -74,49 +74,6 @@ span.blocklyTreeLabel {
      Custom icons
 *******************************/
 
-span.blocklyTreeIcon.blocklyTreeIconloops::before {
-    content: "\f10b";
-}
-
-span.blocklyTreeIcon.blocklyTreeIconlogic::before {
-    content: "\f10a";
-}
-
-span.blocklyTreeIcon.blocklyTreeIconvariables::before {
-    content: "\f111";
-}
-
-span.blocklyTreeIcon.blocklyTreeIconmath::before {
-    content: "\f10c";
-}
-
 span.blocklyTreeIcon.blocklyTreeIconfunctions {
     font-family: 'legoIcons' !important;
-}
-span.blocklyTreeIcon.blocklyTreeIconfunctions::before {
-    content: "\f108";
-}
-
-span.blocklyTreeIcon.blocklyTreeIconarrays::before {
-    content: "\f109";
-}
-
-span.blocklyTreeIcon.blocklyTreeIcontext::before {
-    content: "\f110";
-}
-
-span.blocklyTreeIcon.blocklyTreeIconaddpackage::before {
-    content: "\f105";
-}
-
-span.blocklyTreeIcon.blocklyTreeIconadvancedcollapsed::before {
-    content: "\f113";
-}
-
-span.blocklyTreeIcon.blocklyTreeIconadvancedexpanded::before {
-    content: "\f114";
-}
-
-span.blocklyTreeIcon.blocklyTreeIconsearch::before {
-    content: "\f11a";
 }


### PR DESCRIPTION
Merge with https://github.com/Microsoft/pxt/pull/4205

No longer authoring toolbox icons with CSS, using blockIcons in pxtarget instead