### PR TITLE
Updates to the download dialog

### DIFF
--- a/editor/extension.ts
+++ b/editor/extension.ts
@@ -54,6 +54,14 @@ pxt.editor.initExtensionsAsync = function (opts: pxt.editor.ExtensionOptions): P
                         </div>
                     </div>
                 </div>
+            </div>
+            <div class="ui one column grid">
+                <div class="column">
+                    <a href="/troubleshoot" target="_blank" class="ui segment container yellow">
+                        <i class="icon exclamation circle large" aria-hidden="true"></i>
+                        ${lf("Something wrong? Click here to troubleshoot..")}
+                    </a>
+                </div>
             </div>`;
 
             return confirmAsync({
@@ -63,20 +71,16 @@ pxt.editor.initExtensionsAsync = function (opts: pxt.editor.ExtensionOptions): P
                 hideCancel: true,
                 hideAgree: false,
                 agreeLbl: lf("I got it"),
-                buttons: [{
-                    label: lf("I don't see the EV3 drive"),
-                    url: '/troubleshoot',
-                    class: 'troubleshoot left floated'
-                }, downloadAgain ? {
+                buttons: [downloadAgain ? {
                     label: fn,
                     icon: "download",
-                    class: "lightgrey focused",
+                    className: "lightgrey focused",
                     url,
                     fileName: fn
                 } : undefined, docUrl ? {
                     label: lf("Help"),
                     icon: "help",
-                    class: "lightgrey",
+                    className: "lightgrey",
                     url: docUrl
                 } : undefined]
                 //timeout: 20000


### PR DESCRIPTION
Fixes for the download dialog (className)
and update the location of the troubleshoot link.

<img width="843" alt="screen shot 2018-05-01 at 12 45 25 pm" src="https://user-images.githubusercontent.com/16690124/39482567-8ca3a0ec-4d3d-11e8-8182-dd0ca3c08e5f.png">
