### PR TITLE
shorten ambient / reflected color sensor blocks

### DIFF
--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -185,7 +185,7 @@ namespace sensors {
          * @param handler the code to run when detected
          */
         //% help=sensors/color-sensor/on-light-detected
-        //% block="on **color sensor** %this|detected %mode|%condition"
+        //% block="on **color sensor** %this|%mode|%condition"
         //% blockId=colorOnLightDetected
         //% parts="colorsensor"
         //% blockNamespace=sensors
@@ -202,7 +202,7 @@ namespace sensors {
          * @param color the color to detect
          */
         //% help=sensors/color-sensor/pause-until-light-detected
-        //% block="pause until **color sensor** %this|detected %mode|%condition"
+        //% block="pause until **color sensor** %this|%mode|%condition"
         //% blockId=colorPauseUntilLightDetected
         //% parts="colorsensor"
         //% blockNamespace=sensors


### PR DESCRIPTION
Attempt to shorten color sensor ambient and reflected blocks by removing detected keyword.

<img width="494" alt="screen shot 2018-05-02 at 9 53 36 pm" src="https://user-images.githubusercontent.com/16690124/39560494-4bdd33ea-4e53-11e8-8817-293ce2f8ea70.png">
