### PR TITLE
Color sensor light

### DIFF
--- a/sim/visuals/nodes/colorSensorView.ts
+++ b/sim/visuals/nodes/colorSensorView.ts
@@ -36,7 +36,10 @@ namespace pxsim.visuals {
 
         private updateSensorLightVisual(color: string) {
             const sensorHole = this.content.getElementById(this.normalizeId(ColorSensorView.sensor_hole_id)) as SVGCircleElement;
-            sensorHole.style.fill = color;
+            sensorHole.style.stroke = color;
+            if (color != '#ffffff') {
+                sensorHole.style.strokeWidth = '2px';
+            }
         }
     }
 }


### PR DESCRIPTION
Issue was raised at the design meeting that the color of the color senor light may be interpreted as the current color detected. So I made it more subtle and appear more like a shining light with a color rather than the whole thing filled.
<img width="266" alt="screen shot 2018-05-03 at 8 13 48 am" src="https://user-images.githubusercontent.com/16690124/39585568-ff74a716-4ea9-11e8-8d18-b5bc785f9e29.png">
