### PR TITLE
add "pause on run" flag to disable waiting after command

### DIFF
--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -293,7 +293,7 @@ namespace motors {
             }
 
             this._move(useSteps, stepsOrTime, speed);
-            this._pauseOnRun(stepsOrTime);
+            this.pauseOnRun(stepsOrTime);
         }
 
         /**


### PR DESCRIPTION
Add a flag "motor.setPauseOnRun(false)" to disable waiting for the end of a command that specifies an angle.

Needs HW testing.
- [ ] test single motor
- [ ] test steer + delay