### PR TITLE
Fix piano field editor (when it's on its own)

### DIFF
--- a/libs/music/piano.ts
+++ b/libs/music/piano.ts
@@ -5,7 +5,8 @@ namespace music {
      */
     //% weight=1 help=music/note-frequency
     //% blockId=device_note block="%note"
-    //% shim=TD_ID color="#FFFFFF" colorSecondary="#FFFFFF"
+    //% shim=TD_ID
+    //% color="#FFFFFF" colorSecondary="#FFFFFF" colorTertiary="#D67923"
     //% note.fieldEditor="note" note.defl="1046"
     //% note.fieldOptions.editorColour="#FF1493" note.fieldOptions.decompileLiterals=true
     //% note.fieldOptions.minNote=52 note.fieldOptions.maxNote=75


### PR DESCRIPTION
Relies on https://github.com/Microsoft/pxt/pull/4440
Fixes similar issue to https://github.com/Microsoft/pxt-adafruit/issues/598