### PR TITLE
Edits from LEGO team review

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@
 {
     "name": "Prepare",
     "imageUrl": "/static/lessons/firmware.png",
-    "description": "To use Microsoft MakeCode with your EV3 Brick, you will need to install the latest LEGO MINDSTORMS Education EV3 firmware - version 1.10 or higher. Follow these steps to install the latest firmware from LEGO.",
+    "description": "To use Microsoft MakeCode with your EV3 Brick, you will need to install the latest LEGO® MINDSTORMS® Education EV3 firmware. Follow these steps to make sure you're up to date and install the latest firmware if you need to.",
     "label": "New? Start Here!",
     "labelClass": "red ribbon large",
     "url": "https://makecode.mindstorms.com/troubleshoot"

--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -1,6 +1,6 @@
 # Troubleshooting download problems
 
-If your're having trouble getting your code onto the EV3 Brick, try these steps to see if you can fix the problem.
+If you're having trouble getting your code onto the EV3 Brick, try these steps to see if you can fix the problem.
 
 ## Check your **@drivename@** firmware
 
@@ -8,11 +8,11 @@ MakeCode needs a firmware version of **1.10E** or higher installed on your brick
 
 ### ~hint
 
-Firmware is the software that runs all the basic operations on your brick. Your programs run with the firmware to make the @boardname@ do all the things you want it to do. Your brick comes with the firmware already installed. You could have a brick with an older version of firmware that needs updating in order for it to work properly with MakeCode.
+Firmware is the software that runs all the basic operations on your EV3 Brick. Your programs and the firmware work together to make the EV3 Brick do all things you want it to. Your EV3 Brick comes with firmware pre-installed, but it may need to be updated to work properly with MakeCode.
 
 ### ~
 
-To check the the firmware version on your brick:
+To check the the firmware version on your EV3 Brick:
 
 1. Go to the **Settings** menu (it's under the wrench tool symbol)
 2. Select **Brick Info** and press ENTER
@@ -31,7 +31,7 @@ If your a firmware version level is less than **1.10E**, you need to install an 
 
 ### ~ hint
 
-**Recommended:** Upgrade with the **[EV3 Manager](https://ev3manager.education.lego.com/)**
+**Recommended:** Upgrade with the **[EV3 Device Manager](https://ev3manager.education.lego.com/)**
 
 ### ~
 
@@ -45,27 +45,27 @@ On Windows, it looks like this in Explorer:
 
 If you don't see the **@drivename@** drive, make sure your brick is powered on and check that your USB connection is good.
 
-## Is my brick charged and powered on?
+## The display on the EV3 Brick is blank
 
-Make sure your brick is charged and powered on. If your brick doesn't turn on, find the charger and plug it into wall power, then connect it to your brick. Does it turn on and start up?
+Make sure your EV3 Brick is charged and powered on. If your it doesn't turn on, find the charger and plug it into wall power, then connect it to your EV3 Brick. Does it turn on and start up?
 
-## Is my USB connection good?
+## I still can't see my @drivename@ drive
 
-Make sure that one end of your USB cable is firmly inserted into the port on the computer and the other end is connected to the brick. If you still can't see the **@drivename@** drive, try a different port on the computer. If that doesn't work then maybe your cable is bad or you need to reset the brick.
+Make sure that one end of your USB cable is firmly inserted into a USB port on the computer and the other end is connected to the EV3 Brick. If you still can't see the **@drivename@** drive, try a different port on the computer. If that doesn't work then maybe your cable is faulty or you need to reset the EV3 Brick.
 
-## How do I reset my brick?
+## How do I reset my EV3 Brick?
 
-If you think your USB connection is good and you still can't see your **@drivename@** drive, try giving the brick a reset. You can follow these steps to reset:
+If you think your USB connection is good and you still can't see your **@drivename@** drive, try giving the EV3 Brick a reset. You can follow these steps to reset:
 
 1. Using a finger from one hand, press the **Back** button. Keep holding it.
-2. With your other hand, use two fingers to hold down both the **Left** button and the **Enter** button. You hold these at the same time while you're still pressing the **Back** button.
+2. With your other hand, use two fingers to hold down both the **Left** button and the **Center** button. You hold these at the same time while you're still pressing the **Back** button.
 3. Now, release your finger from the **Back** button.
-4. When the brick says "Starting.." you can let go of the **Left** and **Enter** buttons.
+4. When the EV3 Brick says "Starting.." you can let go of the **Left** and **Enter** buttons.
 
-You can also watch this [How to Reset](https://www.lego.com/en-us/videos/themes/mindstorms/how-to-reset-the-ev3-p-brick-fbcbdbed398e4e12a7ce30fa662c54be) video to see how to do a reset.
+You can also watch this [How to Reset](https://www.lego.com/en-us/videos/themes/mindstorms/how-to-reset-the-ev3-p-brick-fbcbdbed398e4e12a7ce30fa662c54be) video.
 
 ## LEGO Support
 
-If you've checked everything here and can't get the **@drivename@** drive to show up on your computer, you can't make the brick reset, or your program just won't download, then try the [Troubleshooting Walkthrough](https://www.lego.com/en-us/service/help/products/themes-sets/mindstorms/lego-mindstorms-ev3-troubleshooting-walkthrough-408100000009798).
+If you've checked everything here and can't get the **@drivename@** drive to show up on your computer, you can't make the EV3 Brick reset, or your program just won't download, then try the [Troubleshooting Walkthrough](https://www.lego.com/en-us/service/help/products/themes-sets/mindstorms/lego-mindstorms-ev3-troubleshooting-walkthrough-408100000009798).
 
 You can also find more help at [LEGO Support](https://www.lego.com/en-us/mindstorms/support).

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -12,14 +12,14 @@ Step by step guides to coding your @boardname@.
   "url":"/tutorials/wake-up",
   "imageUrl":"/static/tutorials/wake-up.png"
 }, {
-  "name": "Make An Animation",
-  "description": "Create a custom animation on your brick screen.",
+  "name": "Make an Animation",
+  "description": "Create a custom animation on your EV3 Brick Display.",
   "cardType": "tutorial",
   "url":"/tutorials/make-an-animation",
   "imageUrl":"/static/tutorials/make-an-animation.png"
 }, {
   "name": "What Animal Am I?",
-  "description": "Create different animal sounds and have someone guess the what the animal is.",
+  "description": "Create different animal effects and have someone guess what the animal is.",
   "cardType": "tutorial",
   "url":"/tutorials/what-animal-am-i",
   "imageUrl":"/static/tutorials/what-animal-am-i.png"
@@ -37,7 +37,7 @@ Step by step guides to coding your @boardname@.
 ```codecard
 [{
   "name": "Run Motors",
-  "description": "Use the buttons to start and stop the large and medium motors.",
+  "description": "Use the EV3 Brick buttons to start and stop the Large Motor and Medium Motor.",
   "cardType": "tutorial",
   "url":"/tutorials/run-motors",
   "imageUrl":"/static/tutorials/run-motors.png"
@@ -49,13 +49,13 @@ Step by step guides to coding your @boardname@.
 ```codecard
 [{
   "name": "Touch to Run",
-  "description": "Press the Touch sensor and run a motor.",
+  "description": "Press the Touch Sensor and run a motor.",
   "cardType": "tutorial",
   "url":"/tutorials/touch-to-run",
   "imageUrl":"/static/tutorials/touch-to-run.png"
 }, {
   "name": "Touch Sensor Values",
-  "description": "Check the value of a Touch sensor and stop a motor if pressed.",
+  "description": "Check the value of a Touch Sensor and stop a motor if pressed.",
   "cardType": "tutorial",
   "url":"/tutorials/touch-sensor-values",
   "imageUrl":"/static/tutorials/touch-sensor-values.png"
@@ -67,19 +67,19 @@ Step by step guides to coding your @boardname@.
 ```codecard
 [{
   "name": "What Color?",
-  "description": "Use the Color sensor to detect different colors.",
+  "description": "Use the Color Sensor to detect different colors.",
   "cardType": "tutorial",
   "url":"/tutorials/what-color",
   "imageUrl":"/static/tutorials/what-color.png"
 }, {
   "name": "Line Following",
-  "description": "Use the Color sensor to make a robot follow a line.",
+  "description": "Use the Color Sensor to make a robot follow a line.",
   "cardType": "tutorial",
   "url":"/tutorials/line-following",
   "imageUrl":"/static/tutorials/line-following.png"
 }, {
   "name": "Red Light, Green Light",
-  "description": "Play Red Light, Green Light using the Color sensor and the robot.",
+  "description": "Play Red Light, Green Light using the Color Sensor and the robot.",
   "cardType": "tutorial",
   "url":"/tutorials/redlight-greenlight",
   "imageUrl":"/static/tutorials/redlight-greenlight.png"
@@ -103,7 +103,7 @@ Step by step guides to coding your @boardname@.
 ```codecard
 [{
   "name": "Security Alert",
-  "description": "Build an security alert using the infrared sensor.",
+  "description": "Build an security alert using the Infrared Sensor.",
   "cardType": "tutorial",
   "url":"/tutorials/security-alert",
   "imageUrl":"/static/tutorials/security-alert.png"

--- a/docs/tutorials/line-following.md
+++ b/docs/tutorials/line-following.md
@@ -2,7 +2,7 @@
 
 ## Introduction @unplugged
 
-Make a program to follow a line using the Color sensor and reflected light. Let's test reflected light to see if it's white or black (on the line), and drive our robot accordingly. 
+Make your @boardname@ robot follow a line using the Color Sensor's Reflected Light Intensity Mode.
 
 ![Brick with color sensors tracking a yellow line](/static/tutorials/line-following/line-following.gif)
 
@@ -36,7 +36,7 @@ forever(function () {
 
 ## Step 3
 
-Open the ``||sensors:Sensors||`` Toolbox drawer. From the **Color Sensor** section, drag out a ``||sensors:color sensor light||`` value block and drop it into the second slot of the ``||logic:0 < 0||`` comparison block, replacing the `0`.
+Open the ``||sensors:Sensors||`` Toolbox drawer. Drag out a ``||sensors:color sensor light||`` value block and drop it into the second slot of the ``||logic:0 < 0||`` comparison block, replacing the second `0`.
 
 ```blocks
 forever(function () {
@@ -50,7 +50,7 @@ forever(function () {
 
 ## Step 4
 
-If the value of the reflected light is greater than 40% (white or very light), our robot is outside the line, so steer to the left. In the ``||logic:0 < 0||`` comparison block change the compared value to `40` replacing `0`. 
+If the value of the reflected light is greater than 40% (white or very light), our robot is outside the line, so steer to the left. In the ``||logic:0 < 0||`` comparison block change the first compared value from `0` to `40`. 
 
 ```blocks
 forever(function () {
@@ -64,7 +64,7 @@ forever(function () {
 
 ## Step 5
 
-Open the ``||motors:Motors||`` Toolbox drawer. Drag out **2** ``||motors:tank large motors||`` blocks and drop one of them into the ``||logic:if||`` part, and the other into the ``||logic:else||`` part of the ``||logic:if then else||`` block.
+Open the ``||motors:Motors||`` Toolbox drawer. Drag out **2** ``||motors:tank motors||`` blocks and drop one of them into the ``||logic:if||`` part, and the other into the ``||logic:else||`` part of the ``||logic:if then else||`` block.
 
 ```blocks
 forever(function () {
@@ -78,7 +78,7 @@ forever(function () {
 
 ## Step 6
 
-In the first ``||motors:tank large motors||`` block in the ``||logic:if||`` clause, change the speed values of the motors from ``50%``, ``50%`` to ``5%``, ``15%``. This slows down the robot, and steers it to the left (because the **C** motor is driving faster than the **B** motor).
+In the first ``||motors:tank motors||`` block in the ``||logic:if||`` clause, change the speed values of the motors from ``50%``, ``50%`` to ``5%``, ``15%``. This slows down the robot and steers it to the left (because the **C** motor is driving faster than the **B** motor).
 
 ```blocks
 forever(function () {
@@ -92,7 +92,7 @@ forever(function () {
 
 ## Step 7
 
-In the second ``||motors:tank large motors||`` block in the ``||logic:else||`` clause, change the speed values of the motors from ``50%``, ``50%`` to ``15%``, ``5%``.  This slows down the robot, and steers it to the right (because the **B** motor is driving faster than the **C** motor).
+In the second ``||motors:tank motors||`` block in the ``||logic:else||`` clause, change the speed values of the motors from ``50%``, ``50%`` to ``15%``, ``5%``.  This slows down the robot and steers it to the right (because the **B** motor is driving faster than the **C** motor).
 
 ```blocks
 forever(function () {
@@ -110,11 +110,10 @@ Use the EV3 simulator to try out your code.
 
 ![Brick with color sensors tracking a yellow line](/static/tutorials/line-following/line-following.gif)
 
-Move the slider under the Color Sensor to change the reflected light and check that motors 
-are moving as you would expect!
+Move the slider under the Color Sensor to change the reflected light intensity and check that motors are moving as you would expect.
 
 ## Step 9
 
-Plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the brick.
+Plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the EV3 Brick.
 
-Attach a Color Sensor to Port 3 of your brick, and attach your brick to a driving base with large motors attached to Ports B and C. See the instructions for building a _Driving Base with Color Sensor Down_. Test your program by positioning your robot to the right of a dark, thick line and then let it drive! 
+Attach a Color Sensor to Port 3 of your EV3 Brick, and attach your brick to a driving base with large motors attached to Ports B and C. See the instructions for building a _Driving Base with Color Sensor Down_. Test your program by positioning your robot to the right of a dark, thick line and then let it drive! 

--- a/docs/tutorials/make-an-animation.md
+++ b/docs/tutorials/make-an-animation.md
@@ -2,9 +2,9 @@
 
 ## Introduction @unplugged
 
-Create a custom animation for your @boardname@.
+Create a custom animation for your EV3 Brick
  
-![Button press on brick](/static/tutorials/make-an-animation/button-pressed.gif)
+![Button press on EV3 Brick](/static/tutorials/make-an-animation/button-pressed.gif)
 
 ## Step 1
 
@@ -46,7 +46,7 @@ brick.showString("Press my button!", 1)
 
 ## Step 5
 
-Try out your code in the EV3 simulator!
+Try out your code in the EV3 Brick simulator!
 
 Press the ``Enter`` button and check that the image shows up as you expected.
 
@@ -64,4 +64,4 @@ brick.showString("Press my button!", 1)
 
 ## Step 7
 
-Plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the brick.
+Plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the EV3 Brick.

--- a/docs/tutorials/music-brick.md
+++ b/docs/tutorials/music-brick.md
@@ -25,7 +25,7 @@ brick.showString("Press my buttons to make music!", 1)
 
 ## Step 3
 
-Open the ``||brick:Brick||`` Toolbox drawer. From the **Buttons** section, drag out an ``||brick:on button||`` block onto the Workspace (you can put it anywhere).
+Open the ``||brick:Brick||`` Toolbox drawer. From the **Buttons** section, drag out an ``||brick:on button||`` block anywhere onto the Workspace.
 
 ```blocks
 brick.buttonEnter.onEvent(ButtonEvent.Pressed, function () {
@@ -68,7 +68,7 @@ brick.showString("Press my buttons to make music!", 1)
 
 ## Step 6
 
-Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the brick.
+Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the EV3 Brick.
 
 You can add more ``||brick:on button||`` blocks to the Workspace and create other ``||music:play tone||`` melodies when different buttons are pressed to transform your brick into a musical instrument!
  

--- a/docs/tutorials/object-near.md
+++ b/docs/tutorials/object-near.md
@@ -134,6 +134,6 @@ forever(function () {
 
 ## Step 10
 
-Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the brick.
+Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the EV3 Brick.
 
-Attach an Ultrasonic Sensor to Port 4 of your brick. Test your program by putting an object at different distances in front of the Ultrasonic Sensor – an object 50 centimeters or closer should be detected. 
+Attach an Ultrasonic Sensor to Port 4 of your EV3 Brick. Test your program by putting an object at different distances in front of the Ultrasonic Sensor – an object 50 centimeters or closer should be detected. 

--- a/docs/tutorials/redlight-greenlight.md
+++ b/docs/tutorials/redlight-greenlight.md
@@ -2,13 +2,13 @@
 
 ## Introduction @unplugged
 
-Use the ``||sensors:pause color sensor||`` block to play Red Light, Green Light with your @boardname@ robot! 
+Use the ``||sensors:pause until color sensor detected||`` block to play Red Light, Green Light with your @boardname@ robot! 
 
 ![Brick simulation with color sensor and motors](/static/tutorials/redlight-greenlight/redlight-greenlight.gif)
 
 ## Step 1
 
-Open the ``||sensors:Sensors||`` Toolbox drawer. Drag out **2** ``||sensors:pause color sensor||`` blocks onto the Workspace, and drop them into the ``||loops:forever||`` loop.
+Open the ``||sensors:Sensors||`` Toolbox drawer. Drag out **2** ``||sensors:pause until color sensor detected||`` blocks onto the Workspace, and drop them into the ``||loops:forever||`` loop.
 
 ```blocks
 forever(function () { 
@@ -19,7 +19,7 @@ forever(function () {
 
 ## Step 2
 
-In the first ``||sensors:pause color sensor||`` block, use the second drop-down menu to select the "Green" color.  In the second ``||sensors:pause color sensor||`` block, use the second drop-down menu to select the "Red" color. 
+In the first ``||sensors:pause until color sensor detected||`` block, use the second drop-down menu to select the Green color.  In the second ``||sensors:pause until color sensor detected||`` block, use the second drop-down menu to select the Red color. 
 
 ![Color selection dropdown](/static/tutorials/redlight-greenlight/pause-color-sensor-dropdown.png)
 
@@ -32,7 +32,7 @@ forever(function () {
 
 ## Step 3
 
-Open the ``||motors:Motors||`` Toolbox drawer. Drag out a ``||motors:tank large motors||`` block onto the Workspace, and drop in between the ``||sensors:pause color sensor||`` blocks.
+Open the ``||motors:Motors||`` Toolbox drawer. Drag out a ``||motors:tank motors||`` block onto the Workspace, and drop in between the ``||sensors:pause until color sensor detected||`` blocks.
 
 ```blocks
 forever(function () { 
@@ -44,7 +44,7 @@ forever(function () {
 
 ## Step 4
 
-Open the ``||motors:Motors||`` Toolbox drawer. Drag out a ``||motors:stop all motors||`` block onto the Workspace, and drop it in after the second ``||sensors:pause color sensor||`` block in the ``||loops:forever||`` loop.
+Open the ``||motors:Motors||`` Toolbox drawer. Drag out a ``||motors:stop all motors||`` block onto the Workspace, and drop it in after the second ``||sensors:pause until color sensor detected||`` block in the ``||loops:forever||`` loop.
 
 ```blocks
 forever(function () { 
@@ -57,6 +57,6 @@ forever(function () {
 
 ## Step 5
  
-Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the brick.
+Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the EV3 Brick.
 
-Attach a Color Sensor to Port 3 of your brick, and attach your brick to a driving base with large motors attached to Ports B and C. See the building instructions for: _Driving Base with Color Sensor Forward_. Test your program by putting a green or red piece of paper or LEGO brick in front of the color sensor.
+Attach a Color Sensor to Port 3 and attach your EV3 Brick to a driving base with Large Motors attached to Ports B and C. See the building instructions for: _Driving Base with Color Sensor Forward_. Test your program by putting a green or red piece of paper or LEGO brick in front of the Color Sensor.

--- a/docs/tutorials/run-motors.md
+++ b/docs/tutorials/run-motors.md
@@ -2,13 +2,13 @@
 
 ## Introduction @unplugged
 
-Use the buttons to start and stop the large and medium motors.
+Use the buttons to start and stop the Large Motor and Medium Motor.
  
 ![Motors in simulator running](/static/tutorials/run-motors/run-motors.gif)
 
 ## Step 1
 
-Open the ``||brick:Brick||`` Toolbox drawer. Drag out **2** ``||brick:on button||`` blocks onto the Workspace (you can place these anywhere on the Workspace).
+Open the ``||brick:Brick||`` Toolbox drawer. Drag out **2** ``||brick:on button||`` blocks anywhere onto the Workspace.
 
 ```blocks
 brick.buttonEnter.onEvent(ButtonEvent.Pressed, function () {
@@ -49,9 +49,9 @@ brick.buttonDown.onEvent(ButtonEvent.Pressed, function () {
 
 ## Step 4
 
-The ``||motors:run||`` blocks specify which type of motor to run (Large or Medium), and which port the motor is attached to (Ports A, B, C, or D). The default setting is to run the large motor attached to port A at 50% speed.
+The ``||motors:run||`` blocks specify which type of motor to run (Large Motor or Medium Motor), and which port the motor is attached to (Ports A, B, C, or D). The default setting is to run the Large Motor attached to Port A at 50% speed.
 
-When we press the Down button, we want our motor to run in the reverse direction. In the ``||motors:run||`` block that is in the ``||brick:on button down pressed||`` block, change the speed value from ``50%`` to ``-50%``. 
+When we press the ``down`` button, we want our motor to run in the reverse direction. In the ``||motors:run||`` block that is in the ``||brick:on button down pressed||`` block, change the speed value from ``50%`` to ``-50%``. 
  
 ![Motor speed select field](/static/tutorials/run-motors/run-speed-field.png)
 
@@ -104,7 +104,7 @@ brick.buttonRight.onEvent(ButtonEvent.Pressed, function () {
 
 ## Step 7
 
-For the ``||motors:run||`` blocks that are in the ``||brick:on button left||`` and ``||brick:on button right||`` blocks, use the drop-down menu to select a ``medium motor`` on port ``D``. 
+For the ``||motors:run||`` blocks that are in the ``||brick:on button left||`` and ``||brick:on button right||`` blocks, use the drop-down menu to select a ``medium motor`` on Port ``D``. 
 
 | | | |
 |-|-|-|
@@ -146,7 +146,7 @@ brick.buttonRight.onEvent(ButtonEvent.Pressed, function () {
 
 ## Step 9
 
-Let’s also change the speed that our Medium motors are running at. In the ``||motors:run medium motor||`` block that is in the ``||brick:on button left||`` block, change the speed from ``50%`` to ``10%``.
+Let’s also change the speed that our Medium Motor is running at. In the ``||motors:run medium motor||`` block that is in the ``||brick:on button left||`` block, change the speed from ``50%`` to ``10%``.
 
 ```blocks
 brick.buttonUp.onEvent(ButtonEvent.Pressed, function () {
@@ -206,7 +206,7 @@ brick.buttonEnter.onEvent(ButtonEvent.Pressed, function () {
 
 ## Step 12
 
-Open the ``||motors:Motors||`` Toolbox drawer. Drag out a ``||motors:stop all motors||`` block onto the Workspace, and drop into the ``||brick:on button||`` enter block.
+Open the ``||motors:Motors||`` Toolbox drawer. Drag out a ``||motors:stop all motors||`` block onto the Workspace, and drop it into the ``||brick:on button enter||`` block.
 
 ```blocks
 brick.buttonUp.onEvent(ButtonEvent.Pressed, function () { 
@@ -228,6 +228,6 @@ brick.buttonEnter.onEvent(ButtonEvent.Pressed, function () {
 
 ## Step 13
 
-Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the brick.
+Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the EV3 Brick.
 
-Attach a Large motor to Port A, and a Medium motor to Port D. Test your program by pressing the different buttons to see whether the correct motors are running as expected.
+Attach a Large Motor to Port A, and a Medium Motor to Port D. Test your program by pressing the different buttons to see whether the correct motors are running as expected.

--- a/docs/tutorials/security-alert.md
+++ b/docs/tutorials/security-alert.md
@@ -2,13 +2,13 @@
 
 ## Introduction @unplugged
 
-The Infrared Sensor uses infrared light waves to detect proximity to the robot. Build an security alert using the infrared sensor. 
+The Infrared Sensor uses infrared light waves to detect proximity to the robot. Build an security alert using the Infrared Sensor. 
  
 ![Brick in simulator with infrared sensor](/static/tutorials/security-alert/security-alert.gif)
 
 ## Step 1
 
-Open the ``||sensors:Sensors||`` Toolbox drawer. Drag out an ``||sensors:on infrared||`` block onto the Workspace (you can place this anywhere). Use the second drop-down menu to select ``detected``.
+Open the ``||sensors:Sensors||`` Toolbox drawer. Drag out an ``||sensors:on infrared object||`` block onto the Workspace (you can place this anywhere). Select ``detected`` from the second dropdown menu.
 
 ![Sensor detect method dropdown selections](/static/tutorials/security-alert/detect-method-dropdown.png)
 
@@ -20,7 +20,7 @@ sensors.infrared1.onEvent(InfraredSensorEvent.ObjectDetected, function () {
 
 ## Step 2
 
-Open the ``||brick:Brick||`` Toolbox drawer. From the **Screen** section, drag out a ``||brick:show image||`` block onto the Workspace, and drop it into the ``||sensors:on infrared||`` block.
+Open the ``||brick:Brick||`` Toolbox drawer. From the **Screen** section, drag out a ``||brick:show image||`` block onto the Workspace, and drop it into the ``||sensors:on infrared object||`` block.
 
 ```blocks
 sensors.infrared1.onEvent(InfraredSensorEvent.ObjectDetected, function () {
@@ -42,7 +42,7 @@ sensors.infrared1.onEvent(InfraredSensorEvent.ObjectDetected, function () {
 
 ## Step 4
 
-Open the ``||brick:Brick||`` Toolbox drawer. From the **Buttons** section, drag out a ``||brick:set status light||`` block onto the Workspace, and drop it after the ``||brick:show image||`` block. 
+Open the ``||brick:Brick||`` Toolbox drawer. From the **Buttons** section, drag out a ``||brick:set status light to||`` block onto the Workspace, and drop it after the ``||brick:show image||`` block. 
 
 ```blocks
 sensors.infrared1.onEvent(InfraredSensorEvent.ObjectDetected, function () {
@@ -53,7 +53,7 @@ sensors.infrared1.onEvent(InfraredSensorEvent.ObjectDetected, function () {
 
 ## Step 5
 
-In the ``||brick:set status light||`` block, use the drop-down menu to select the ``red flash`` light 
+In the ``||brick:set status light to||`` block, use the drop-down menu to select the ``red flash`` light 
  
 ![Status light selection dropdown list](/static/tutorials/security-alert/set-status-light-dropdown.png)
 
@@ -66,7 +66,7 @@ sensors.infrared1.onEvent(InfraredSensorEvent.ObjectDetected, function () {
 
 ## Step 6
 
-Open the ``||loops:Loops||`` Toolbox drawer. Drag a ``||loops:repeat||`` loop onto the Workspace, and drop it after the ``||brick:set status light||`` block. 
+Open the ``||loops:Loops||`` Toolbox drawer. Drag a ``||loops:repeat||`` loop onto the Workspace, and drop it after the ``||brick:set status light to||`` block. 
 
 ```blocks
 sensors.infrared1.onEvent(InfraredSensorEvent.ObjectDetected, function () {
@@ -100,6 +100,6 @@ In the ``||music:play sound effect until done||`` block, use the drop-down menu 
 
 ## Step 9
 
-Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the brick.
+Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the EV3 Brick.
 
-Attach an Infrared Sensor to Port 1 of your brick. Test your program by putting an object increasingly closer to the Infrared Sensor – your Intruder Alert should trigger when you get too close! 
+Attach an Infrared Sensor to Port 1 of your Ev3 Brick. Test your program by putting an object increasingly closer to the Infrared Sensor – your Intruder Alert should trigger when you get too close! 

--- a/docs/tutorials/touch-sensor-values.md
+++ b/docs/tutorials/touch-sensor-values.md
@@ -2,13 +2,13 @@
 
 ## Introduction @unplugged
 
-Use the Touch sensor value to stop a running motor.
+Use the Touch Sensor value to stop a running motor.
 
 ![Touch sensor and motor attached to brick](/static/tutorials/touch-sensor-values/touch-to-stop.gif)
 
 ## Step 1
 
-Open the ``||brick:Brick||`` Toolbox drawer. Drag an ``||brick:on button||`` block onto the Workspace, and place it anywhere on the Workspace.
+Open the ``||brick:Brick||`` Toolbox drawer. Drag an ``||brick:on button||`` block onto the Workspace, and place it anywhere.
 
 ```blocks
 brick.buttonEnter.onEvent(ButtonEvent.Pressed, function () {

--- a/docs/tutorials/touch-to-run.md
+++ b/docs/tutorials/touch-to-run.md
@@ -2,13 +2,13 @@
 
 ## Introduction @unplugged
 
-Use the Touch sensor to run a motor.
+Use the Touch Sensor to run a motor.
 
 ![Large motor connected to brick](/static/tutorials/touch-to-run/touch-to-run.gif)
 
 ## Step 1
 
-Open the ``||sensors:Sensors||`` Toolbox drawer. Drag out **2** ``||sensors:on touch||`` blocks onto the Workspace (you can place these anywhere).
+Open the ``||sensors:Sensors||`` Toolbox drawer. Drag out **2** ``||sensors:on touch||`` blocks anywhere onto the Workspace.
 
 ```blocks
 sensors.touch1.onEvent(ButtonEvent.Pressed, function () {
@@ -62,6 +62,6 @@ sensors.touch1.onEvent(ButtonEvent.Released, function () {
 
 ## Step 5
 
-Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the brick.
+Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the EV3 Brick.
 
-Attach a Large motor to Port A, and a Touch sensor to Port 1 on your brick. Test your program by pressing and releasing the touch sensor – does the motor start and stop as expected?
+Attach a Large Motor to Port A, and a Touch Sensor to Port 1 on your EV3 Brick. Test your program by pressing and releasing the touch sensor – does the motor start and stop as expected?

--- a/docs/tutorials/wake-up.md
+++ b/docs/tutorials/wake-up.md
@@ -16,7 +16,7 @@ brick.showMood(moods.sleeping)
 
 ## Step 2
 
-Notice your brick is snoring with eyes closed in the simulator! Let’s wake her up. Open the ``||brick:Brick||`` Toolbox drawer again. Drag out **2** more ``||brick:show mood||`` blocks and drop them into the ``||brick:on start||`` block also.
+Notice your EV3 Brick is snoring with eyes closed in the simulator! Let’s wake it up. Open the ``||brick:Brick||`` Toolbox drawer again. Drag out **2** more ``||brick:show mood||`` blocks and drop them into the ``||brick:on start||`` block also.
 
 ```blocks
 brick.showMood(moods.sleeping) 

--- a/docs/tutorials/what-animal-am-i.md
+++ b/docs/tutorials/what-animal-am-i.md
@@ -16,21 +16,21 @@ brick.showString("Hello world", 1)
 
 ## Step 2
 
-In the ``||brick:show string||`` block, type the text ``"Guess what animal?"`` to replace ``"Hello world"``.
+In the ``||brick:show string||`` block, type the text ``"Guess teh animal"`` to replace ``"Hello world"``.
 
 ```blocks
-brick.showString("Guess what animal?", 1)
+brick.showString("Guess the animal", 1)
 ```
 
 ## Step 3
 
-Open the ``||brick:Brick||`` Toolbox drawer. From the **Buttons** section, drag out an ``||brick:on button||`` block and put it anywhere in the Workspace.
+Open the ``||brick:Brick||`` Toolbox drawer. From the **Buttons** section, drag out an ``||brick:on button||`` block anywhere onto the Workspace.
 
 ```blocks
 brick.buttonEnter.onEvent(ButtonEvent.Pressed, function () { 
      
 }) 
-brick.showString("Guess what animal?", 1)
+brick.showString("Guess the animal", 1)
 ```
 
 ## Step 4
@@ -43,7 +43,7 @@ In the ``||brick:on button||`` block, use the drop-down menu to select the ``lef
 brick.buttonLeft.onEvent(ButtonEvent.Pressed, function () { 
      
 }) 
-brick.showString("Guess what animal?", 1) 
+brick.showString("Guess the animal", 1) 
 ```
 
 ## Step 5
@@ -63,7 +63,7 @@ brick.buttonUp.onEvent(ButtonEvent.Pressed, function () {
 brick.buttonDown.onEvent(ButtonEvent.Pressed, function () { 
      
 }) 
-brick.showString("Guess what animal?", 1) 
+brick.showString("Guess the animal", 1) 
 ```
 
 ## Step 6
@@ -83,7 +83,7 @@ brick.buttonUp.onEvent(ButtonEvent.Pressed, function () {
 brick.buttonDown.onEvent(ButtonEvent.Pressed, function () { 
     brick.showImage(images.expressionsBigSmile) 
 }) 
-brick.showString("Guess what animal?", 0)
+brick.showString("Guess the animal", 0)
 ```
 
 ## Step 7
@@ -105,7 +105,7 @@ brick.buttonUp.onEvent(ButtonEvent.Pressed, function () {
 brick.buttonDown.onEvent(ButtonEvent.Pressed, function () {
     brick.showImage(images.objectsPirate)
 })
-brick.showString("Guess what animal?", 0)
+brick.showString("Guess the animal", 0)
 ```
 
 ## Step 8
@@ -129,7 +129,7 @@ brick.buttonDown.onEvent(ButtonEvent.Pressed, function () {
     brick.showImage(images.objectsPirate)
     music.playSoundEffect(sounds.animalsCatPurr)
 })
-brick.showString("Guess what animal?", 0)
+brick.showString("Guess the animal", 0)
 ```
 
 ## Step 9
@@ -155,7 +155,7 @@ brick.buttonDown.onEvent(ButtonEvent.Pressed, function () {
     brick.showImage(images.objectsPirate)
     music.playSoundEffect(sounds.animalsSnakeHiss)
 })
-brick.showString("Guess what animal?", 0)
+brick.showString("Guess the animal", 0)
 ```
 
 ## Step 10

--- a/docs/tutorials/what-color.md
+++ b/docs/tutorials/what-color.md
@@ -2,7 +2,7 @@
 
 ## Introduction @unplugged
 
-Use the Color sensor to detect different colors.
+Use the Color Sensor to detect different colors.
 
 ![Simulator view with color sensor](/static/tutorials/what-color/color-detector.gif)
 
@@ -24,7 +24,7 @@ brick.showString("What color?", 1)
 
 ## Step 3
 
-Open the ``||sensors:Sensors||`` Toolbox drawer. Drag out **3** ``||sensors:on color sensor detected||`` blocks onto the Workspace (you can place these anywhere). 
+Open the ``||sensors:Sensors||`` Toolbox drawer. Drag out **3** ``||sensors:on color sensor detected||`` blocks anywhere onto the Workspace.
 
 ```blocks
 sensors.color3.onColorDetected(ColorSensorColor.Blue, function () {
@@ -57,7 +57,7 @@ brick.showString("What color?", 1)
 
 ## Step 5
 
-Open the ``||brick:Brick||`` Toolbox drawer. From the **Buttons** section, drag out a **3** ``||brick:set status light||`` blocks and drop one of them each into the ``||sensors:on color detected||`` blocks.
+Open the ``||brick:Brick||`` Toolbox drawer. From the **Buttons** section, drag out **3** ``||brick:set status light||`` blocks and drop one of them each into the ``||sensors:on color sensor detected||`` blocks.
 
 ```blocks
 sensors.color3.onColorDetected(ColorSensorColor.Red, function () {
@@ -91,7 +91,7 @@ brick.showString("What color?", 1)
 
 ## Step 7
 
-Open the ``||music:Music||`` Toolbox drawer. Drag out **3** ``||music:play sound effect||`` blocks and drop one of them each into the ``||sensors:on color detected||`` blocks after the ``||brick:set status light||`` block.
+Open the ``||music:Music||`` Toolbox drawer. Drag out **3** ``||music:play sound effect||`` blocks and drop one of them each into the ``||sensors:on color sensor detected||`` blocks after the ``||brick:set status light||`` block.
 
 ```blocks
 sensors.color3.onColorDetected(ColorSensorColor.Red, function () {
@@ -131,6 +131,6 @@ brick.showString("What color?", 1)
 
 ## Step 9
 
-Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the brick.
+Now, plug your EV3 Brick into the computer with the USB cable, and click the **Download** button at the bottom of your screen. Follow the directions to save your program to the EV3 Brick.
 
-Attach a Color Sensor to Port 3 of your brick. Test your program by flashing Red, Green and Yellow colored paper or use LEGO bricks in front of the Color Sensor.
+Attach a Color Sensor to Port 3 of your EV3 Brick. Test your program by flashing Red, Green and Yellow colored paper or use LEGO bricks in front of the Color Sensor.


### PR DESCRIPTION
Take aways:
* Parts are CAP'd like: Large Motor, Infrared Sensor, etc.
* All occurrences of "brick" referring to the actual device are ALWAYS stated as: 'EV3 Brick' (where's my ``boardNickname`` macro?)
* The 'Enter' button is called 'Centre' (if it's UK English I guess). We get a pass on this for the moment.
* The 'Screen' is the 'Display'. Also, we get a pass on this right now.

Also, it looks like we ditched the manual firmware update step in _troubleshoot.md_? Going from a "Prepare" gallery thumb to a "Troubleshooting" page seems confusing although it accomplishes the same thing. Change the title to "Preparing and troubleshooting your EV3 Brick"?
