### PR TITLE
Match Color Sensor ports in the 'Try' tutorial

### DIFF
--- a/docs/getting-started/try.md
+++ b/docs/getting-started/try.md
@@ -135,15 +135,15 @@ Keeping the Large Motor connected to **Port D**, connect the Color Sensor to **P
 
 ```blocks
 brick.buttonEnter.onEvent(ButtonEvent.Pressed, function () {
-    sensors.color3.pauseUntilColorDetected(ColorSensorColor.Green)
+    sensors.color4.pauseUntilColorDetected(ColorSensorColor.Green)
     motors.largeD.run(50, 1, MoveUnit.Rotations)
 })
 ```
 
-* Using the same program, replace the ``||sensors:pause until touch 1||`` block with a ``||sensors:pause color sensor 3||`` for color block.
+* Using the same program, replace the ``||sensors:pause until touch 1||`` block with a ``||sensors:pause color sensor 4||`` for color block.
 
 ```block
-sensors.color3.pauseUntilColorDetected(ColorSensorColor.Green)
+sensors.color4.pauseUntilColorDetected(ColorSensorColor.Green)
 ```
 
 * Select the color you want to detect (e.g., green).


### PR DESCRIPTION
- [x] Make the examples and text set to Port 4 to match illustration for color sensor.

RE: #681 