### PR TITLE
Fix browser download

### DIFF
--- a/editor/deploy.ts
+++ b/editor/deploy.ts
@@ -60,7 +60,7 @@ const rbfTemplate = `
 4c45474f580000006d000100000000001c000000000000000e000000821b038405018130813e8053
 74617274696e672e2e2e0084006080XX00448581644886488405018130813e80427965210084000a
 `
-export function deployCoreAsync(resp: pxtc.CompileResult, isCli = false) {
+export function deployCoreAsync(resp: pxtc.CompileResult) {
     let w: pxt.editor.Ev3Wrapper
 
     let filename = resp.downloadFileBaseName || "pxt"
@@ -101,7 +101,7 @@ export function deployCoreAsync(resp: pxtc.CompileResult, isCli = false) {
         if (pxt.commands && pxt.commands.electronDeployAsync) {
             return pxt.commands.electronDeployAsync(resp);
         }
-        if (!isCli && pxt.commands && pxt.commands.saveOnlyAsync) {
+        if (pxt.commands && pxt.commands.saveOnlyAsync) {
             return pxt.commands.saveOnlyAsync(resp);
         }
         return Promise.resolve();
@@ -121,10 +121,7 @@ export function deployCoreAsync(resp: pxtc.CompileResult, isCli = false) {
         .then(() => w.flashAsync(rbfPath, rbfBIN))
         .then(() => w.runAsync(rbfPath))
         .then(() => {
-            if (isCli)
-                return w.disconnectAsync()
-            else
-                return Promise.resolve()
+            return w.disconnectAsync()
             //return Promise.delay(1000).then(() => w.dmesgAsync())
         }).catch(e => {
             // if we failed to initalize, retry


### PR DESCRIPTION
Bug has been there since the beginning (https://github.com/Microsoft/pxt-ev3/commit/e6a72ba56a63f4689dbd4bc77f40da1365163c96). The `isCli` parameter is dead code that was meant for debugging purposes.

The problem surfaced when we bumped to latest pxt-core, which now sends a second arg to `deployCoreAsync`. That caused `isCli` to become truthy, which caused the deploy code to do nothing.

The fix gets rid of `isCli` parameter.