### PR TITLE
Fix tank and steer blocks in the simulator

### DIFF
--- a/sim/state/motornode.ts
+++ b/sim/state/motornode.ts
@@ -30,7 +30,7 @@ namespace pxsim {
         }
 
         getSpeed() {
-            return this.speed * (this.polarity == 0 ? -1 : 1);
+            return this.speed * (!this._synchedMotor && this.polarity == 0 ? -1 : 1);
         }
 
         getAngle() {


### PR DESCRIPTION
Fix tank and steer blocks in the simulator, making them ignore polarity just like labview

Fixes https://github.com/Microsoft/pxt-ev3/issues/688