### PR TITLE
Enable additional langs for new translations

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -102,7 +102,11 @@
         "crowdinProject": "kindscript",
         "selectLanguage": true,
         "availableLocales": [
-            "en"
+            "en",
+            "de",
+            "ja",
+            "ru",
+            "zh-CN"
         ],
         "highContrast": true,
         "docMenu": [


### PR DESCRIPTION
Enable editor languages for German (de), Japanese (ja), Russian (ru), and Chinese Simplified (zh-cn).

This matches the strings and markdown translations received from LEGO.