### PR TITLE
Fix the double entry for 'About' in SUMMARY

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -123,3 +123,7 @@
         * [log](/reference/console/log)
         * [log value](/reference/console/log-value)
         * [send to screen](/reference/console/send-to-screen)
+
+## #misc
+
+## devs


### PR DESCRIPTION
RE: #762 

Seems that the entries in the ``## Miscellaneous`` and ``##Developers`` sections in the base _SUMMARY.md_ show up with another path level:

![image](https://user-images.githubusercontent.com/27789908/43972946-dd8a2084-9c8a-11e8-8221-94f72f2d4e31.png)

![image](https://user-images.githubusercontent.com/27789908/43972964-f258a5da-9c8a-11e8-9bb2-7797a1049496.png)
Additionally, the ``/about`` path has another entry in the top at the beginning of the summary.

These sections, however, aren't shown in the actual render of the target TOC so I've added empty section overrides to the target SUMMARY

```
## #misc

## devs
```

Instead of taking this from pxt:

```
## Miscellaneous #misc

* Miscellaneous
    * [About](/about)
    * [Support](/support)
    * [Translate](/translate)
    * [Sharing projects](/share)
    * [Offline support](/offline)
    * [Save](/save)
```

So that it now shows as:

![image](https://user-images.githubusercontent.com/27789908/43973193-ac36c69e-9c8b-11e8-897e-95f732dcc034.png)
