### PR TITLE
Derive 'base' package file list from pxt-common-packages

### DIFF
--- a/libs/base/pxt.json
+++ b/libs/base/pxt.json
@@ -1,28 +1,3 @@
 {
-    "name": "base",
-    "description": "The base library",
-    "files": [
-        "README.md",
-        "pxt-core.d.ts",
-        "pxt.cpp",
-        "pxtbase.h",
-        "core.cpp",
-        "pxt-helpers.ts",
-        "buffer.cpp",
-        "shims.d.ts",
-        "enums.d.ts",
-        "loops.cpp",
-        "math.ts",
-        "ns.ts",
-        "control.cpp",
-        "control.ts",
-        "console.ts",
-        "eventcontext.ts"
-    ],
-    "testFiles": [
-        "test.ts"
-    ],
-    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/base",
-    "public": true,
-    "dependencies": {}
+    "additionalFilePath": "../../node_modules/pxt-common-packages/libs/base"
 }


### PR DESCRIPTION
This way it doesn't break when the file list changes