### PR TITLE
Adding link instructions to lessons with PDFs

### DIFF
--- a/docs/coding/autonomous-parking.md
+++ b/docs/coding/autonomous-parking.md
@@ -12,13 +12,19 @@ Design cars that can park themselves safely without driver intervention.
 * What would it take to ensure that autonomous cars are safe?
 * What types of movements do autonomous cars need to perform?
 
-## Construct 
+## Construct
 
 ### Build
 
 Build a @boardname@ vehicle that can park itself safely without driver intervention. Start by constructing this model:
 
 [![EV3- Robot Driving Base](/static/coding/autonomous-parking/ev3-robot-driving-base.jpg)](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/building-instructions/ev3-rem-driving-base-79bebfc16bd491186ea9c9069842155e.pdf)
+
+### ~hint
+
+If clicking the above image doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
+
+### ~
 
 ### Check
 
@@ -28,7 +34,7 @@ Before you program, check:
 * Are the wheels correctly installed?
 * Are the wheels rotating freely?
 
-### Program 
+### Program
 
 Write a program that will make the robot turn three times in various ways.
 
@@ -109,7 +115,7 @@ Click Download and follow the instructions to get your code onto your EV3 Brick.
 
 ### Differentiation
 
-Create a program that simulates displaying appropriate warning lights while parking. 
+Create a program that simulates displaying appropriate warning lights while parking.
 
 ### ~hint
 
@@ -164,8 +170,8 @@ Click Download and follow the instructions to get your code onto your EV3 Brick.
 
 * Click on the JavaScript tab and experiment with changing the values in the code.
 * Add a custom image or sounds from the Brick or Music menus.
-* Create a video of your project, especially your final presentation and your robot’s performance. Explain some important features of your software program. 
-* Include an image of your program with comments. 
-* Add a team photograph! 
+* Create a video of your project, especially your final presentation and your robot’s performance. Explain some important features of your software program.
+* Include an image of your program with comments.
+* Add a team photograph!
 
 Congratulations! What will you design next?

--- a/docs/coding/line-detection.md
+++ b/docs/coding/line-detection.md
@@ -24,6 +24,12 @@ Build red and green “lights” for your robot to detect. You can use LEGO bric
 
 [![IMAGE: Color Squares](/static/coding/line-detection/ev3-color-squares.jpg)](https://le-www-live-s.legocdn.com/sc/media/files/support/mindstorms%20ev3/building-instructions/design%20engineering%20projects/color%20squares-0a88dfd98bb2e64b5b8151fc422bae36.pdf)
 
+### ~hint
+
+If clicking the above images doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
+
+### ~
+
 ### Check
 
 Before you program, check:
@@ -51,7 +57,7 @@ Consider using these blocks in your solution:
 
 ```block
 loops.forever(function () {
-	
+
 })
 motors.largeBC.steer(0, 50)
 sensors.color3.pauseUntilColorDetected(ColorSensorColor.Red)
@@ -77,9 +83,9 @@ loops.forever(function () {
 
 ### Download and test
 
-Click **Download** and follow the instructions to get your code onto your EV3 Brick. 
+Click **Download** and follow the instructions to get your code onto your EV3 Brick.
 
-Congratulations! Your robot can stop at a red light. 
+Congratulations! Your robot can stop at a red light.
 
 Now add to your program and have your robot to drive forward again when the light changes from red to green.
 
@@ -102,7 +108,7 @@ loops.forever(function () {
 
 ### Download and test
 
-Click **Download** and follow the instructions to get your code onto your EV3 Brick. 
+Click **Download** and follow the instructions to get your code onto your EV3 Brick.
 
 ## Contemplate
 
@@ -116,7 +122,7 @@ Draw a dark line with tape or marker for your robot to cross.
 
 Consider using these blocks in your solution:
 
-```block 
+```block
 motors.largeBC.steer(0, 50)
 music.playSoundEffect(sounds.systemGeneralAlert)
 ```
@@ -143,7 +149,7 @@ loops.forever(function () {
 
 #### Download and test
 
-Click **Download** and follow the instructions to get your code onto your EV3 Brick. 
+Click **Download** and follow the instructions to get your code onto your EV3 Brick.
 
 #### Differentiation
 
@@ -157,7 +163,7 @@ Consider using these blocks in your solution:
 
 ```block
 while (true) {
-	
+
 }
 motors.largeBC.steer(0, 50)
 ```
@@ -166,7 +172,7 @@ motors.largeBC.steer(0, 50)
 
 ```block
 if (true) {
-	
+
 } else {
 
 }
@@ -215,7 +221,7 @@ forever(function () {
 
 ### Download and test
 
-Click **Download** and follow the instructions to get your code onto your EV3 Brick. 
+Click **Download** and follow the instructions to get your code onto your EV3 Brick.
 
 ### Share
 
@@ -232,8 +238,8 @@ Personalize:
 
 * Click on the **JavaScript** tab and experiment with changing the values in the code.
 * Add a custom image or sounds from the ``||brick:Brick||`` or ``||music:Music||`` menus.
-* Create a video of your project, especially your final presentation and your robot’s performance. Explain some important features of your software program. 
-* Include an image of your program with comments. 
-* Add a team photograph! 
+* Create a video of your project, especially your final presentation and your robot’s performance. Explain some important features of your software program.
+* Include an image of your program with comments.
+* Add a team photograph!
 
 Congratulations! What will you design next?

--- a/docs/coding/object-detection.md
+++ b/docs/coding/object-detection.md
@@ -4,7 +4,7 @@ Design ways to avoid accidents between vehicles and objects in the road.
 
 ![Deer in the road](/static/coding/object-detection/road-deer.jpg)
 
-## Connect 
+## Connect
 
 Think about:
 
@@ -12,7 +12,7 @@ Think about:
 * What do you need to be aware of to avoid collisions with obstacles?
 * What causes traffic jams in high density areas?
 
-## Construct 
+## Construct
 
 ### Build
 
@@ -20,9 +20,15 @@ Build a @boardname@ vehicle that can avoid accidents between vehicles and object
 
 [![EV3 Robot Driving Base](/static/coding/object-detection/ev3-robot-driving-base.jpg)](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/building-instructions/ev3-ultrasonic-sensor-driving-base-61ffdfa461aee2470b8ddbeab16e2070.pdf)
 
-Build an obstacle for your robot to detect. You can build the **cuboid model** out of LEGO bricks or an obstacle of your choice. 
+Build an obstacle for your robot to detect. You can build the **cuboid model** out of LEGO bricks or an obstacle of your choice.
 
 [![Cubiod block](/static/coding/object-detection/ev3-cuboid.jpg)](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/building-instructions/ev3-cuboid-dc93b2e60bed2981e76b3bac9ea04558.pdf)
+
+### ~hint
+
+If clicking the above images doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
+
+### ~
 
 ### Check
 
@@ -38,7 +44,7 @@ Before you program, check:
 * Program your robot to detect any obstacles that might appear while the robot is moving forward (or backward).
 * Make the robot stop when it detects an object that is less than 20 cm away.
 
-Before you program, think about:  
+Before you program, think about:
 * How will you program the robot to detect obstacles?
 * How will you program the robot to stop at obstacles?
 * Which programming blocks will you use?
@@ -59,7 +65,7 @@ motors.stopAll()
 
 ### ~
 
-### Sample Solution 
+### Sample Solution
 
 1. Start the program when EV3 ``enter`` button is pressed.
 2. Turn motors ``B`` and ``C`` on at speed ``50``.
@@ -80,7 +86,7 @@ Click **Download** and follow the instructions to get your code onto your EV3 Br
 
 ## Contemplate
 
-On the road, when a driver sees and object, they slow their car down before coming to a full stop. 
+On the road, when a driver sees and object, they slow their car down before coming to a full stop.
 
 Program your EV3 Driving Base to do the same.
 
@@ -93,7 +99,7 @@ If the Ultrasonic Sensor:
 ### ~hint
 
 Consider using this block in your solution:
- 
+
 ```block
 if (true) {
 }
@@ -101,7 +107,7 @@ if (true) {
 
 ### ~
 
-### Sample Solution 
+### Sample Solution
 
 ```blocks
 loops.forever(function () {
@@ -118,7 +124,7 @@ loops.forever(function () {
 
 Click **Download** and follow the instructions to get your code onto your EV3 Brick. Press the ``center`` button on the EV3 Brick to run the program.
 
-## Continue 
+## Continue
 
 * Get together with other building teams and make a traffic jam by placing all of your robots in a line with varying amounts of space between them.
 * Have everyone start their robots at the same time and see what happens.
@@ -130,8 +136,8 @@ Click **Download** and follow the instructions to get your code onto your EV3 Br
 
 * Share what you think “efficiency in programming” means.
 * Explore the different solutions other programmers came up with.
-* Create a video of your project, especially your final presentation and your robot’s performance. Explain some important features of your software program. 
-* Include an image of your program with comments. 
-* Add a team photograph! 
+* Create a video of your project, especially your final presentation and your robot’s performance. Explain some important features of your software program.
+* Include an image of your program with comments.
+* Add a team photograph!
 
 Congratulations! What will you design next?

--- a/docs/design-engineering/make-it-communicate.md
+++ b/docs/design-engineering/make-it-communicate.md
@@ -1,6 +1,6 @@
 # Make A System That Communicates
 
-## Connect 
+## Connect
 
 ### Design Brief
 
@@ -20,10 +20,10 @@ Think about:
 * What kind of motorized mechanism can be used to control the movements of a robot?
 * How can the robot sense where it is along the path?
 * How can the robot communicate its position?
- 
+
 ![EV3 + LEGO Bricks](/static/lessons/make-it-communicate/ev3-plus-parts.jpg)
 
-## Construct 
+## Construct
 
 ### Build
 
@@ -37,13 +37,19 @@ More building ideas:
 
 [![Color Sensor 2](/static/lessons/make-it-communicate/ev3-color-sensor2.jpg)](https://le-www-live-s.legocdn.com/sc/media/files/support/mindstorms%20ev3/building-instructions/design%20engineering%20projects/color%20sensor_v2-e7fd54b6fa3cdfe36f414c1d2510f9cb.pdf)
 
+### ~hint
 
-Build a path for your robot to follow. You can use electrical tape on a floor, or marker on paper. You can use objects as milestones to indicate a path that can be detected by either the Touch Sensor, Color Sensor, or Ultrasonic Sensor. 
+If clicking the above images doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
 
-### Program 
+### ~
 
-Before you program, think about: 
- 
+
+Build a path for your robot to follow. You can use electrical tape on a floor, or marker on paper. You can use objects as milestones to indicate a path that can be detected by either the Touch Sensor, Color Sensor, or Ultrasonic Sensor.
+
+### Program
+
+Before you program, think about:
+
 * How will you program the robot to follow a path?
 * How will you program the robot to communicate its position?
 * Which programming blocks will you use?
@@ -54,7 +60,7 @@ Explore the different Motor and Sensor blocks in the programming menu.
 
 ### ~
 
-### Sample Solution 
+### Sample Solution
 
 [![Video: EV3 Track Rover](/static/lessons/make-it-communicate/ev3-track-rover.jpg)](https://legoeducation.23video.com/v.ihtml/player.html?token=79c99735f906403a4dd7f2909935983d&source=embed&photo%5fid=19857954)
 
@@ -70,15 +76,21 @@ Two copies of the tracks are built: one for the right side and a mirror image fo
 
 [![Track rover assembled](/static/lessons/make-it-communicate/ev3-track-rover2.jpg)](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/ev3-dep/building%20instructions/track-rover-bi-6aadb1b053df0c58a0dea108b5ce0eea.pdf)
 
-### Sample Program Solution 
+### ~hint
 
-This program works with the Track Rover. If you create a different robot, adjust the program to fit your solution. 
+If clicking the above image doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
 
-Program summary: 
+### ~
+
+### Sample Program Solution
+
+This program works with the Track Rover. If you create a different robot, adjust the program to fit your solution.
+
+Program summary:
 
 * If the Color Sensor sees black, Motor B runs at -50 power and Motor C turns off.
 * If the Color Sensor sees white, Motor B turns off and Motor C runs at -50 power.
-* If the Color Sensor sees green, all motors stop and the green sound plays. 
+* If the Color Sensor sees green, all motors stop and the green sound plays.
 * The robot waits one second, then motors move forward.
 * If the Color Sensor sees red, all motors stop, and the red sound plays.
 * The robot waits one second, then motors move forward.
@@ -108,44 +120,44 @@ forever(function () {
 
 Click Download and follow the instructions to get your code onto your EV3 Brick. Press the center button on the EV3 Brick to run the program.
 
-## Contemplate 
+## Contemplate
 
-### Test and Analyze 
+### Test and Analyze
 
 As you work on your solution:
 
-1. Describe one part of your design that worked especially well. 
-2. Describe one design change that you had to make. 
-3. What will you try next? 
+1. Describe one part of your design that worked especially well.
+2. Describe one design change that you had to make.
+3. What will you try next?
 
 
-### Review and Revise 
+### Review and Revise
 
-Take a moment to reflect on your robot solution. 
+Take a moment to reflect on your robot solution.
 
 Think about:
 
-* Can the robot’s movement be more accurate? 
+* Can the robot’s movement be more accurate?
 * What are some ways that others have solved the problem?
 
 Describe two ways you could improve your robot.
 
-## Continue 
+## Continue
 
 ### Personalize your project
 
-* Add/remove LEGO elements to improve the way your robot moves. 
+* Add/remove LEGO elements to improve the way your robot moves.
 * Click on the JavaScript tab and experiment with changing the values in the code.
 * Add a custom image or sounds by adding blocks from the Brick or Music menus.
 
-## Communicate 
+## Communicate
 
 Here are some ideas:
 
-* Create a video of your project, especially your final presentation and your robot’s performance. 
-* Explain some important features of your software program. 
-* Produce a building guide for your model by taking a series of photographs as you deconstruct it. 
-* Include an image of your program with comments. 
-* Add a team photograph! 
+* Create a video of your project, especially your final presentation and your robot’s performance.
+* Explain some important features of your software program.
+* Produce a building guide for your model by taking a series of photographs as you deconstruct it.
+* Include an image of your program with comments.
+* Add a team photograph!
 
 Congratulations! What will you design next?

--- a/docs/design-engineering/make-it-move.md
+++ b/docs/design-engineering/make-it-move.md
@@ -32,18 +32,24 @@ If you want some building help you can follow these instructions.
 
 Click [here](https://le-www-live-s.legocdn.com/sc/media/files/support/mindstorms%20ev3/building-instructions/design%20engineering%20projects/toddle%20bot-3dcad146d7f5deac4753f93e9dcc0739.pdf)
 
+### ~hint
+
+If clicking the above image or link doesn't open the instructions, right-click on the link and choose "Save link as..." to download the PDF.
+
+### ~
+
 ### Program
 
 Before you program, think about:
 
-* How will you program the robot to move? 
+* How will you program the robot to move?
 * How will you program the robot to stop?
 * How will you program the robot to display the distance moved?
 
 Which programming blocks will you use:
 
-* To turn on and turn off the motor or motors? 
-* To display the distance moved? 
+* To turn on and turn off the motor or motors?
+* To display the distance moved?
 
 ### Sample Code
 
@@ -51,7 +57,7 @@ Example code of a robot that moves without wheels using one motor:
 
 * The robot moves with ``large motor D`` rotating at ``-100`` speed
 * The robot moves for ``30000`` milliseconds (30 seconds)
-* The robot stops 
+* The robot stops
 * The robot displays the text ``"30cm"``
 
 ```blocks
@@ -67,7 +73,7 @@ brick.buttonEnter.onEvent(ButtonEvent.Pressed, function () {
 
 Click **Download** and follow the instructions to get your code onto your EV3 Brick. Press the center button on the EV3 Brick to run the program.
 
-## Contemplate 
+## Contemplate
 
 ### Test and Analyze
 

--- a/docs/design-engineering/make-it-smarter.md
+++ b/docs/design-engineering/make-it-smarter.md
@@ -1,6 +1,6 @@
-# Make It Smarter and Faster 
+# Make It Smarter and Faster
 
-## Connect 
+## Connect
 
 ### Design Brief
 
@@ -10,31 +10,31 @@ https://www.youtube.com/watch?v=y9-A_C_08KY
 
 * What do the robots in the video need to be able to sense, plan, and act?
 * What senses do humans have and why are they important to us?
-* How many human-like senses do you see the robots demonstrating? 
+* How many human-like senses do you see the robots demonstrating?
 
-### Brainstorm 
+### Brainstorm
 
 Discuss different solutions to the design brief.
 
-Think about: 
+Think about:
 
-* What kind of creature can it be? 
-* How can it move? 
-* What does it need to be aware so that it stays safe, well fed and warm (or cool)? 
-* Is it looking for food, a safe place to hide or a warm place to soak up the sun? 
-* Will the creature need to move fast or slow? 
-* Will it need to turn? 
+* What kind of creature can it be?
+* How can it move?
+* What does it need to be aware so that it stays safe, well fed and warm (or cool)?
+* Is it looking for food, a safe place to hide or a warm place to soak up the sun?
+* Will the creature need to move fast or slow?
+* Will it need to turn?
 * Will it need to go backward?
 
 ![EV3 and bricks](/static/lessons/make-it-smarter/bricks.png)
 
 ## Construct
- 
+
 ### Build
 
 Think about a creature’s movement for inspiration. Your mechanism can be attached or unattached to the EV3 Brick. You can start by tinkering with the LEGO elements in the picture add then build on.
 
-More building ideas: 
+More building ideas:
 
 | | | | | |
 |-|-|-|-|-|
@@ -53,9 +53,15 @@ More building ideas:
 | [![EV3 Leg 1](/static/lessons/make-it-smarter/ev3-parts-leg-1.jpg)][Leg 1] | | [![EV3 Leg 2](/static/lessons/make-it-smarter/ev3-parts-leg-2.jpg)][Leg 2] | | [![EV3 Leg 3](/static/lessons/make-it-smarter/ev3-parts-leg-3.jpg)][Leg 3] |
 | [Leg 1] | | [Leg 2] | | [Leg 3] |
 
-### Program 
+### ~hint
 
-Before you program, think about:  
+If clicking the above links doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
+
+### ~
+
+### Program
+
+Before you program, think about:
 
 * How will you program the robot to sense?
 * How will you program the robot to respond?
@@ -67,7 +73,7 @@ Before you program, think about:
 
 ### ~
 
-### Sample Solution 
+### Sample Solution
 
 The Insect uses its Ultrasonic Sensor to sense danger and move away from a threat.
 
@@ -86,11 +92,17 @@ Building Instructions:
 
 [![Insect robot](/static/lessons/make-it-smarter/insect-bot.jpg)](https://le-www-live-s.legocdn.com/sc/media/files/support/mindstorms%20ev3/building-instructions/design%20engineering%20projects/insect-94b8a46f0dc5082c9d78ddb734626dc9.pdf)
 
-### Sample Solution 
+### ~hint
 
-This program checks if the Ultrasonic Sensor senses something near. 
+If clicking the above images or links doesn't open the instructions, right-click on the link and choose "Save link as..." to download the PDF.
 
-The blocks inside the ``||loops:forever||`` loop have these actions: 
+### ~
+
+### Sample Solution
+
+This program checks if the Ultrasonic Sensor senses something near.
+
+The blocks inside the ``||loops:forever||`` loop have these actions:
 
 1. Turn on the ``green`` EV3 Brick Status Light.
 2. Wait for Ultrasonic Sensor to detect an object.
@@ -119,44 +131,44 @@ forever(function () {
 
 Click **Download** and follow the instructions to get your code onto your EV3 Brick. Press the center button on the EV3 Brick to run the program.
 
-## Contemplate 
+## Contemplate
 
-### Test and Analyze 
+### Test and Analyze
 
-As you work on your solution: 
-1. Describe one part of your design that worked especially well. 
-2. Describe one design change that you had to make. 
-3. What will you try next? 
+As you work on your solution:
+1. Describe one part of your design that worked especially well.
+2. Describe one design change that you had to make.
+3. What will you try next?
 
-### Review and Revise 
+### Review and Revise
 
-Take a moment to reflect on your robot solution. 
+Take a moment to reflect on your robot solution.
 
-Think about: 
+Think about:
 
-* Does your robot move when the sensor is activated? 
-* If not, what will you change to make the robot’s ability to sense and respond more obvious? 
-* What other behaviors can you add to the robot to make it more realistic? 
+* Does your robot move when the sensor is activated?
+* If not, what will you change to make the robot’s ability to sense and respond more obvious?
+* What other behaviors can you add to the robot to make it more realistic?
 
 Describe two ways you could improve your robot.
 
-## Continue 
+## Continue
 
 Personalize your project:
 
-* Add/remove LEGO elements to improve the way your robot moves. 
+* Add/remove LEGO elements to improve the way your robot moves.
 * Click on the JavaScript tab and experiment with changing the values in the code.
 * Add a custom image or sounds by adding blocks from the Brick or Music menus.
 * Does your robot resemble a creature? Maybe add more craft materials to your project.
 
-## Communicate 
+## Communicate
 
-Here are some ideas: 
+Here are some ideas:
 
-* Create a video of your project, especially your final presentation and your robot’s performance. Explain some important features of your software program. 
-* Produce a building guide for your model by taking a series of photographs as you deconstruct it. 
-* Include an image of your program with comments. 
-* Add a team photograph! 
+* Create a video of your project, especially your final presentation and your robot’s performance. Explain some important features of your software program.
+* Produce a building guide for your model by taking a series of photographs as you deconstruct it.
+* Include an image of your program with comments.
+* Add a team photograph!
 
 Congratulations! What will you design next?
 

--- a/docs/getting-started/use.md
+++ b/docs/getting-started/use.md
@@ -20,6 +20,12 @@ Build the robot driving base:
 
 [![EV3 Driving Base](/static/lessons/common/ev3-driving-base.jpg)](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/building-instructions/ev3-rem-driving-base-79bebfc16bd491186ea9c9069842155e.pdf)
 
+### ~hint
+
+If clicking the above image doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
+
+### ~
+
 ## Make It Move
 
 **Code it:** Create a program that makes the Driving Base move forward and stop at the finish line, which is ``1`` meter away.
@@ -67,6 +73,12 @@ brick.buttonEnter.onEvent(ButtonEvent.Pressed, function () {
 Build and attach an Ultrasonic Sensor to your driving base:
 
 [![EV3 Ultrasonic Sensor Driving Base Building Instructions Main Image](/static/lessons/common/ev3-ultrasonic-sensor-driving-base.jpg)](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/building-instructions/ev3-ultrasonic-sensor-driving-base-61ffdfa461aee2470b8ddbeab16e2070.pdf)
+
+### ~hint
+
+If clicking the above image doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
+
+### ~
 
 ## Detect an Object
 

--- a/docs/lessons/line-detection.md
+++ b/docs/lessons/line-detection.md
@@ -3,7 +3,7 @@
 ## Objective
 
 Design ways to improve driving safety by helping to prevent drivers from falling asleep and causing an accident.
- 
+
 ![Car driving on highway](/static/lessons/line-detection/car-driving.jpg)
 
 ## Connect
@@ -19,6 +19,12 @@ Think about what you have learned, then document it. Describe the problem in you
 ## Construct
 
 Start by constructing this model. Read the building instructions [here](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/building-instructions/ev3-rem-color-sensor-down-driving-base-d30ed30610c3d6647d56e17bc64cf6e2.pdf) first.
+
+### ~hint
+
+If clicking the above image doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
+
+### ~
 
 ![Color sensor on the driving base](/static/lessons/line-detection/color-sensor-driving.jpg)
 
@@ -44,13 +50,13 @@ Create a program that drives the robot forward until the Color Sensor sees red. 
 
 Place a ``||motors:steer large B+C||`` block from ``||motors:Motors||`` under ``||loops:on start||``. Change the speed to 20%.
 
-```blocks 
+```blocks
 motors.largeBC.steer(0, 20)
 ```
 
 ### Step 2
 
-Place a ``||loops:while||`` loop block under ``||motors:steer large B+C||``.  
+Place a ``||loops:while||`` loop block under ``||motors:steer large B+C||``.
 
 ```blocks
 motors.largeBC.steer(0, 20)
@@ -61,7 +67,7 @@ while (true) {
 ### Step 3
 
 Place a ``||sensors:pause until color detected||`` from ``||sensors:Sensors||`` inside the ``||loops:while||`` loop block. Change the color to red.
- 
+
 ```blocks
 motors.largeBC.steer(0, 20)
 while (true) {
@@ -99,7 +105,7 @@ Place a ``||loops:while||`` loop block under ``||loops:on start||``.
 
 ```blocks
 while (true) {
-    
+
 }
 ```
 
@@ -121,7 +127,7 @@ Place a ``||loops:while||`` loop block under the ``||motors:steer large B+C||`` 
 while (true) {
     motors.largeBC.steer(0, 20)
     while (true) {
-        
+
     }
 }
 ```
@@ -141,7 +147,7 @@ while (true) {
 
 ### Step 6
 
-Place a ``||motors:stop all motors||`` block under the ``||sensors:pause until color detected||`` block.  
+Place a ``||motors:stop all motors||`` block under the ``||sensors:pause until color detected||`` block.
 
 ```blocks
 while (true) {
@@ -165,7 +171,7 @@ while (true) {
         motors.stopAll()
     }
     while (true) {
-        
+
     }
 }
 ```
@@ -177,7 +183,7 @@ Place a ``||sensors:pause unril color detected||`` block inside the new ``||loop
 What do you think the program will do?
 
 **Hint:** The motors will run until the Color Sensor detects the color red, then it will stop all motors. The motors will also run and not stop when the color sensor detects the color green.
- 
+
 ```blocks
 while (true) {
     motors.largeBC.steer(0, 20)
@@ -212,7 +218,7 @@ sensors.color3.pauseUntilColorDetected(ColorSensorColor.Yellow)
 music.playSoundEffect(sounds.systemGeneralAlert)
 }
 while (true) {
-    while (true) {      
+    while (true) {
         sensors.color3.pauseUntilLightDetected(LightIntensityMode.Reflected, Light.Bright)
         motors.largeB.run(10)
         motors.largeC.run(-10)
@@ -235,7 +241,7 @@ You will need to constantly debug your program in order to make your robot trave
 
 ```blocks
 while (true) {
-    while (true) {   
+    while (true) {
         sensors.color3.pauseUntilLightDetected(LightIntensityMode.Reflected, Light.Bright)
         motors.largeB.run(10)
         motors.largeC.run(-10)
@@ -252,10 +258,10 @@ while (true) {
 
 Consider the following questions:
 
-1. What challenged you? 
-2. Where there any surprises? 
+1. What challenged you?
+2. Where there any surprises?
 3. How could you improve your program?
-4. Could your program have been more streamlined? 
+4. Could your program have been more streamlined?
 5. Have you used too many blocks?
 6. Is there a more efficient way of building your program?
 7. How could your program be used in real-world scenarios?

--- a/docs/lessons/make-it-move-tutorial.md
+++ b/docs/lessons/make-it-move-tutorial.md
@@ -1,4 +1,4 @@
-# Make It Move Without Wheels 
+# Make It Move Without Wheels
 
 ## Objective @unplugged
 
@@ -24,7 +24,13 @@ The Walker Bot combines an EV3 Frame and two legs that are mirror-images to crea
 The legs in the Walker Bot are designed to show how to change the rotary motion of a motor to reciprocating motion.
 
 Start by reading [these](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/ev3-dep/building%20instructions/walker-bot-bi-180fc24f9298e1dd6201099627d43903.pdf) instructions first.
- 
+
+### ~hint
+
+If clicking the above image doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
+
+### ~
+
 ![@boardname@ Walker Bot](/static/lessons/make-it-move/walker-bot.jpg)
 
  

--- a/docs/lessons/make-it-move.md
+++ b/docs/lessons/make-it-move.md
@@ -1,4 +1,4 @@
-# Make It Move Without Wheels 
+# Make It Move Without Wheels
 
 ## Objective
 
@@ -23,7 +23,13 @@ The Walker Bot combines an EV3 Frame and two legs that are mirror-images to crea
 The legs in the Walker Bot are designed to show how to change the rotary motion of a motor to reciprocating motion.
 
 Start by reading [these](https://le-www-live-s.legocdn.com/sc/media/lessons/mindstorms-ev3/ev3-dep/building%20instructions/walker-bot-bi-180fc24f9298e1dd6201099627d43903.pdf) instructions first.
- 
+
+### ~hint
+
+If clicking the above image doesn't open the instructions, right-click on the image and choose "Save link as..." to download the PDF.
+
+### ~
+
 ![@boardname@ Walker Bot](/static/lessons/make-it-move/walker-bot.jpg)
 
  


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-ev3/issues/741

AFAIK this is a browser bug. Chrome has pretty wide reports of this happening and it seems like they are working on a fix. Until then, let's work around the issue by adding instructions.

![image](https://user-images.githubusercontent.com/13754588/45846441-a2812600-bcdc-11e8-9fb4-2e1b64f9bf6b.png)
