### PR TITLE
Add file delete workaround to 'FLL' page

### DIFF
--- a/docs/fll.md
+++ b/docs/fll.md
@@ -1,4 +1,4 @@
-# MakeCode for FIRST LEGO League
+# MakeCode for _FIRST_ LEGO League
 
 ![FIRST LEGO League logo](/static/fll/fll-logo.png)
 
@@ -82,7 +82,22 @@ You can share your projects by clicking on the Share button in the top left of t
  
 ![Share button in editor](/static/fll/share-program.jpg)
 
-For other common questions, try the FAQ page https://makecode.mindstorms.com/faq. 
+### Why can't I delete my program (*.uf2) files from the Brick?
+
+There's a bug in the firmware which prevents you from deleting the programs (``*.uf2`` files) from your EV3 Brick. There isn't a firmware update to fix this yet. As a workaround, you can temporarily downgrade your firmware version, delete the files, and then upgrade back to the version that works with MakeCode.
+
+Follow these steps to downgrade your firmware version, delete the files, and uprgade back again:
+
+1. Go into **EV3 LabVIEW** - if it's not installed get it [here](https://education.lego.com/en-us/downloads/mindstorms-ev3/software)
+2. Plug in your EV3 Brick and start a new project
+3. Go to the **Tools** menu in the upper right corner, select **Firmware Update**
+4. In the **Firmware Update** dialog box, click on the **Show Details** button
+5. From the **Available Firmware Files** list, select **EV3 Firmware V1.09E**
+6. Click the **Update Firmware** button and wait for the update to complete
+
+Now the firmware version on the EV3 Brick will be **V1.09E**. Also, in the process, the downgrade deleted all of the saved programs from the EV3 Brick. To continue to use MakeCode, the firmware version must be at **V1.10E** or above. So, the Brick firmware needs to be upgraded again. If you don't know or do remember how to do this, see the **Upgrade your @drivename@** section in the [troubleshooting](/troubleshoot) page.
+
+For other common questions, try the FAQ page https://makecode.mindstorms.com/faq.
 
 ## Community connection
 


### PR DESCRIPTION
- [x] Italicize _FIRST_ in _FIRST_ LEGO League.
- [x] Add a FAQ section with the file delete workaround.

Later, we could add a fast gif with the LabVIEW steps for doing the downgrade maybe.

RE: #809