### PR TITLE
Call setOutputType with the right arguments

### DIFF
--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -325,12 +325,15 @@ namespace motors {
         protected setOutputType(large: boolean) {
            for (let i = 0; i < DAL.NUM_OUTPUTS; ++i) {
                 if (this._port & (1 << i)) {
+                    // (0x07: Large motor, Medium motor = 0x08)
                     MotorBase.output_types[i] = large ? 0x07 : 0x08;
                 }
             }
             MotorBase.setTypes();
         }
 
+        // Note, we are having to create our own buffer here as mkCmd creates a buffer with a command
+        // In the case of opOutputSetType, it expects the arguments to be opOutputSetType [type0, type1, type2, type3]
         static setTypes() {
             const b = output.createBuffer(5)
             b.setNumber(NumberFormat.UInt8LE, 0, DAL.opOutputSetType)


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-ev3/issues/825

I first made sure that the we were sending the right commands when we call [syncMotors](https://github.com/Microsoft/pxt-ev3/blob/master/libs/core/output.ts#L677) and I used the firmware source to check that. see c_output.c::cOutputStepSync in the [EV3 firmware source](https://education.lego.com/en-us/support/mindstorms-ev3/developer-kits)

@mmoskal then realized that the cOutputSetType method was a NOP in that file. see c_output.c::cOutputSetType

but cOutputSetTypes was in fact calling a pwm write with a type array that's passed in. see: c_output.c::cOutputSetTypes

This is probably a bug in the firmware itself and how it's documented, but internally the firmware also uses cOutputSetTypes to set types.

In summary, when setting the output type (large / medium motor), we were calling opOutputSetType with arguments: [port_number, type], but after looking at the firmware more closely, the actual arguments for that operation are: [type0, type1, type2, type3]
