### PR TITLE
Re-enable trace from simulator configuration

### DIFF
--- a/pxtarget.json
+++ b/pxtarget.json
@@ -23,6 +23,7 @@
         "streams": true,
         "aspectRatio": 0.5,
         "parts": false,
+        "enableTrace": true,
         "boardDefinition": {
             "visual": "ev3"
         }


### PR DESCRIPTION
We have moved enableTrace to be in appTheme, but since I'm releasing a hotfix, this is not yet in the stable branch that pxt-ev3 is currently mapped to, so I'm returning it to it's original location. 

Currently it will be in both locations, and once we bump pxt-core we can remove it from this location (from under pxtarget.json::simulator)