### PR TITLE
Add in extended offline page

### DIFF
--- a/docs/offline.md
+++ b/docs/offline.md
@@ -1,0 +1,11 @@
+# @extends
+
+## Offline app #target-app
+
+The MakeCode editor is available as app which you can install on a computer with Windows or Mac OS. Once installed, the **[MakeCode Offline App](/offline-app)** lets you create, run, and download your projects to the @boardname@. It works the same as the Web application does in your browser but it's a stand-alone application that will work when a connection to the internet is restricted or not available.
+
+### ~ hint
+
+The [MakeCode Offline App](/offline-app) is currently in development and is made available as a **pre-release** version. 
+
+### ~


### PR DESCRIPTION
Bring in the extended offline page for linking to the offline-app page.

Note: the extended section will appear at the top when this target matches current pxt:
https://github.com/Microsoft/pxt/pull/5285

RE: https://github.com/Microsoft/pxt-microbit/pull/1853#issuecomment-470327378