### PR TITLE
Change the delay time after stopping

### DIFF
--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -220,9 +220,9 @@ namespace motors {
 
         protected settle() {
             // if we've recently completed a motor command with brake
-            // allow 500ms for robot to settle
+            // allow 10ms for robot to settle
             if (this._brake)
-                pause(500);
+                pause(10);
         }
 
         protected pauseOnRun(stepsOrTime: number) {


### PR DESCRIPTION
Change of delay time after stopping from 500 to 10 ms.

When participating in a competition, the problem was discovered that when setBreak is set to true, there is a significant delay when the motors stop. I poked around in the code and found a problem that settle sets a delay of 500 ms. I decided to check. Set 10 ms. Motors after the execution of one instruction now almost immediately begin to execute the next command. And before that, the motors were in delay.

I checked it on a real robot. I did not find any problems in order to use 10 ms. Why was the code written with a delay of 500 ms? Is there an explanation?