### PR TITLE
Multi sensor fix

### DIFF
--- a/libs/core/input.ts
+++ b/libs/core/input.ts
@@ -363,7 +363,7 @@ namespace sensors.internal {
     }
 
     function uartClearChange(port: number) {
-        control.dmesg(`UART retry set mode`);
+        control.dmesg(`UART clear change`);
         const UART_DATA_READY = 8
         const UART_PORT_CHANGED = 1
         while (true) {

--- a/libs/core/input.ts
+++ b/libs/core/input.ts
@@ -71,7 +71,10 @@ namespace sensors.internal {
         IICMM = control.mmap("/dev/lms_iic", IICOff.Size, 0)
         if (!IICMM) control.fail("no iic sensor")
 
-        unsafePollForChanges(500, () => { detectDevices(); return 0; }, (prev, curr) => { });
+        unsafePollForChanges(500, 
+            () => { return hashDevices(); }, 
+            (prev, curr) => { detectDevices(); 
+        });
         sensorInfos.forEach(info => {
             unsafePollForChanges(50, () => {
                 if (info.sensor) return info.sensor._query()
@@ -113,6 +116,15 @@ namespace sensors.internal {
             temp: analogMM.getNumber(NumberFormat.Int16LE, AnalogOff.BatteryTemp),
             current: Math.round(analogMM.getNumber(NumberFormat.Int16LE, AnalogOff.BatteryCurrent) / 10)
         }
+    }
+
+    function hashDevices(): number {
+        const conns = analogMM.slice(AnalogOff.InConn, DAL.NUM_INPUTS)
+        let r = 0;
+        for(let i = 0; i < conns.length; ++i) {
+            r = (r << 8 | conns[i]);
+        }
+        return r;
     }
 
     let nonActivated = 0;


### PR DESCRIPTION
When detecting multiple UART devices, the second device triggers a UART reset in the detect device loop because the status is "changed".

Applying all UART device changes at once in this change.

Note that this does not fix the underlying issue that we crash when the UART configuration changes (e.g. connecting or disconnecting sensors on the fly). I will investigate further to see if this can be fixed too.