### PR TITLE
Single tank

### DIFF
--- a/docs/reference/motors/synced/steer.md
+++ b/docs/reference/motors/synced/steer.md
@@ -41,7 +41,7 @@ motors.largeBC.steer(-15, -75)
 
 ## ~ hint
 
-Only one set of tank/steer motors will run at the same time. Once you launch tank/steer, it will cancel the previous tank/steer command.
+Only one set of synchronized motors will run at the same time. Once you launch tank/steer, it will cancel any existing synchronized speed command.
 
 ## ~
 

--- a/docs/reference/motors/synced/steer.md
+++ b/docs/reference/motors/synced/steer.md
@@ -39,6 +39,13 @@ motors.largeBC.steer(-15, -75)
 
 ## ~
 
+## ~ hint
+
+Only one set of tank/steer motors will run at the same time. Once you launch tank/steer, it will cancel the previous tank/steer command.
+
+## ~
+
+
 ## Examples
 
 ### Make a slight right

--- a/docs/reference/motors/synced/tank.md
+++ b/docs/reference/motors/synced/tank.md
@@ -37,7 +37,7 @@ motors.largeBC.tank(-75, -75)
 
 ## ~ hint
 
-Only one set of tank/steer motors will run at the same time. Once you launch tank/steer, it will cancel the previous tank/steer command.
+Only one set of synchronized motors will run at the same time. Once you launch tank/steer, it will cancel any existing synchronized speed command.
 
 ## ~
 

--- a/docs/reference/motors/synced/tank.md
+++ b/docs/reference/motors/synced/tank.md
@@ -35,6 +35,12 @@ motors.largeBC.tank(-75, -75)
 
 ## ~
 
+## ~ hint
+
+Only one set of tank/steer motors will run at the same time. Once you launch tank/steer, it will cancel the previous tank/steer command.
+
+## ~
+
 ## Examples
 
 ### Tank forward and backward

--- a/sim/state/motornode.ts
+++ b/sim/state/motornode.ts
@@ -65,6 +65,11 @@ namespace pxsim {
             delete this._synchedMotor;
         }
 
+        clearSyncCmd() {
+            if (this._synchedMotor)
+                this.clearSpeedCmd();
+        }
+
         setLarge(large: boolean) {
             this.id = large ? NodeType.LargeMotor : NodeType.MediumMotor;
             // large 170 rpm  (https://education.lego.com/en-us/products/ev3-large-servo-motor/45502)

--- a/sim/state/output.ts
+++ b/sim/state/output.ts
@@ -80,6 +80,12 @@ namespace pxsim {
                             const brake = pxsim.BufferMethods.getNumber(buf, BufferMethods.NumberFormat.Int8LE, 12);
 
                             const motors = ev3board().getMotor(port);
+                            // cancel any other sync command
+                            for(const motor of ev3board().getMotors().filter(motor => motors.indexOf(motor) < 0)) {
+                                motor.clearSyncCmd()
+                            }
+
+                            // apply commands to all motors
                             for (const motor of motors) {
                                 const otherMotor = motors.filter(m => m.port != motor.port)[0];
                                 motor.setSyncCmd(


### PR DESCRIPTION
Fix simulator to match hardware behavior: only 1 set set of synched motors at any time.

https://github.com/microsoft/pxt-ev3/issues/854