### PR TITLE
add a run to avoid tight loop hogging

### DIFF
--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -267,6 +267,9 @@ namespace motors {
                 this.pauseUntilReady();
                 // allow robot to settle
                 this.settle();
+            } else {
+                // give a breather to the event system in tight loops
+                pause(1);
             }
         }
 


### PR DESCRIPTION
Add a pause(1) for motors.run command (we already pause when a distance is provided)