### PR TITLE
lock execution thread before exiting

### DIFF
--- a/libs/core/linux.cpp
+++ b/libs/core/linux.cpp
@@ -524,6 +524,7 @@ void stopProgram() {
 }
 
 extern "C" void target_reset() {
+    pthread_mutex_trylock(&execMutex);
     stopMotors();
     stopProgram();
     if (lmsPid)


### PR DESCRIPTION
We have a race with the esc button where the program starts the motors while we are exiting .