### PR TITLE
polarity in synched motor

### DIFF
--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -159,6 +159,7 @@ namespace motors {
         private _accelerationTime: number;
         private _decelerationSteps: number;
         private _decelerationTime: number;
+        private _inverted: boolean;
 
         protected static output_types: number[] = [0x7, 0x7, 0x7, 0x7];
 
@@ -176,6 +177,7 @@ namespace motors {
             this._accelerationTime = 0;
             this._decelerationSteps = 0;
             this._decelerationTime = 0;
+            this._inverted = false;
         }
 
         /**
@@ -227,7 +229,8 @@ namespace motors {
             this.init();
             const b = mkCmd(this._port, DAL.opOutputPolarity, 1)
             b.setNumber(NumberFormat.Int8LE, 2, inverted ? 0 : 1);
-            writePWM(b)
+            writePWM(b);
+            this._inverted = inverted;
         }
 
         /** 
@@ -294,8 +297,9 @@ namespace motors {
         }
 
         private normalizeSchedule(speed: number, step1: number, step2: number, step3: number, unit: MoveUnit): MoveSchedule {
+            // motor polarity is not supported at the firmware level for sync motor operations
             const r: MoveSchedule = {
-                speed: Math.clamp(-100, 100, speed >> 0),
+                speed: Math.clamp(-100, 100, speed >> 0) * (this._inverted ? -1 : 1),
                 useSteps: true,
                 steps: [step1 || 0, step2 || 0, step3 || 0]
             }
@@ -562,6 +566,7 @@ namespace motors {
 
         private __init() {
             this.setOutputType(this._large);
+            this.setInverted(false);
         }
 
         /**

--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -159,6 +159,7 @@ namespace motors {
         private _accelerationTime: number;
         private _decelerationSteps: number;
         private _decelerationTime: number;
+        private _inverted: boolean;
 
         protected static output_types: number[] = [0x7, 0x7, 0x7, 0x7];
 
@@ -176,6 +177,7 @@ namespace motors {
             this._accelerationTime = 0;
             this._decelerationSteps = 0;
             this._decelerationTime = 0;
+            this._inverted = false;
         }
 
         /**
@@ -225,14 +227,11 @@ namespace motors {
         //% help=motors/motor/set-inverted
         setInverted(inverted: boolean) {
             this.init();
-            this.internalSetInverted(inverted);
-        }
-
-        protected internalSetInverted(inverted: boolean) {
+            this._inverted = inverted;
         }
 
         protected invertedFactor(): number {
-            return 1;
+            return this._inverted ? -1 : 1;
         }
 
         /** 
@@ -571,12 +570,6 @@ namespace motors {
             this.setInverted(false);
         }
 
-        protected internalSetInverted(inverted: boolean) {
-            const b = mkCmd(this._port, DAL.opOutputPolarity, 1)
-            b.setNumber(NumberFormat.Int8LE, 2, inverted ? 0 : 1);
-            writePWM(b);
-        }
-
         /**
          * Gets motor actual speed.
          * @param motor the port which connects to the motor
@@ -689,12 +682,10 @@ namespace motors {
 
     //% fixedInstances
     export class SynchedMotorPair extends MotorBase {
-        private _inverted: boolean;
 
         constructor(ports: Output) {
             super(ports, () => this.__init());
             this.markUsed();
-            this._inverted = false;
         }
 
         markUsed() {
@@ -703,14 +694,6 @@ namespace motors {
 
         private __init() {
             this.setOutputType(true);
-        }
-
-        protected internalSetInverted(inverted: boolean) {
-            this._inverted = inverted;
-        }
-
-        protected invertedFactor(): number {
-            return this._inverted ? -1 : 1;
         }
 
         /**

--- a/sim/state/motornode.ts
+++ b/sim/state/motornode.ts
@@ -93,7 +93,9 @@ namespace pxsim {
         }
 
         private polarityFactor() {
-            return this.polarity == 0 ? -1 : 1;
+            // polarity is supported at the firmware level for single motor
+            // overriden for synched motors
+            return (this.polarity == 0 && !!this._synchedMotor) ? -1 : 1;
         }
 
         reset() {
@@ -149,7 +151,7 @@ namespace pxsim {
                     case DAL.opOutputPower:
                         // assume power == speed
                         // TODO: PID
-                        this.speed = this.speedCmdValues[0];
+                        this.speed = this.speedCmdValues[0] * this.polarityFactor();
                         break;
                     case DAL.opOutputTimeSpeed:
                     case DAL.opOutputTimePower:

--- a/sim/state/motornode.ts
+++ b/sim/state/motornode.ts
@@ -94,8 +94,8 @@ namespace pxsim {
 
         private polarityFactor() {
             // polarity is supported at the firmware level for single motor
-            // overriden for synched motors
-            return (this.polarity == 0 && !!this._synchedMotor) ? -1 : 1;
+            // but ignored for double motors
+            return (this.polarity == 0 && !this._synchedMotor) ? -1 : 1;
         }
 
         reset() {

--- a/sim/state/motornode.ts
+++ b/sim/state/motornode.ts
@@ -31,7 +31,7 @@ namespace pxsim {
         }
 
         getSpeed() {
-            return Math.round(this.speed * (!this._synchedMotor && this.polarityFactor()));
+            return Math.round(this.speed * this.polarityFactor());
         }
 
         getAngle() {
@@ -95,7 +95,7 @@ namespace pxsim {
         private polarityFactor() {
             // polarity is supported at the firmware level for single motor
             // but ignored for double motors
-            return (this.polarity == 0 && !this._synchedMotor) ? -1 : 1;
+            return this.polarity == 0 ? -1 : 1;
         }
 
         reset() {

--- a/sim/state/motornode.ts
+++ b/sim/state/motornode.ts
@@ -9,7 +9,6 @@ namespace pxsim {
         private angle: number = 0;
         private tacho: number = 0;
         private speed: number = 0;
-        private polarity: number = 1; // -1, 1 or -1
 
         private started: boolean;
         private speedCmd: DAL;
@@ -31,7 +30,7 @@ namespace pxsim {
         }
 
         getSpeed() {
-            return Math.round(this.speed * this.polarityFactor());
+            return Math.round(this.speed);
         }
 
         getAngle() {
@@ -80,22 +79,6 @@ namespace pxsim {
 
         isLarge(): boolean {
             return this.id == NodeType.LargeMotor;
-        }
-
-        setPolarity(polarity: number) {
-            // Either 1 or 255 (reverse)
-            /*
-                -1 : Motor will run backward  
-                0 : Motor will run opposite direction  
-                1 : Motor will run forward             
-            */
-            this.polarity = polarity;
-        }
-
-        private polarityFactor() {
-            // polarity is supported at the firmware level for single motor
-            // but ignored for double motors
-            return this.polarity == 0 ? -1 : 1;
         }
 
         reset() {
@@ -151,14 +134,14 @@ namespace pxsim {
                     case DAL.opOutputPower:
                         // assume power == speed
                         // TODO: PID
-                        this.speed = this.speedCmdValues[0] * this.polarityFactor();
+                        this.speed = this.speedCmdValues[0];
                         break;
                     case DAL.opOutputTimeSpeed:
                     case DAL.opOutputTimePower:
                     case DAL.opOutputStepPower:
                     case DAL.opOutputStepSpeed: {
                         // ramp up, run, ramp down, <brake> using time
-                        const speed = this.speedCmdValues[0] * this.polarityFactor();
+                        const speed = this.speedCmdValues[0];
                         const step1 = this.speedCmdValues[1];
                         const step2 = this.speedCmdValues[2];
                         const step3 = this.speedCmdValues[3];
@@ -198,7 +181,7 @@ namespace pxsim {
                     case DAL.opOutputStepSync:
                     case DAL.opOutputTimeSync: {
                         const otherMotor = this._synchedMotor;
-                        const speed = this.speedCmdValues[0] * this.polarityFactor();
+                        const speed = this.speedCmdValues[0];
                         const turnRatio = this.speedCmdValues[1];
                         // if turnratio is negative, right motor at power level
                         // right motor -> this.port > otherMotor.port

--- a/sim/state/motornode.ts
+++ b/sim/state/motornode.ts
@@ -31,7 +31,7 @@ namespace pxsim {
         }
 
         getSpeed() {
-            return Math.round(this.speed * (!this._synchedMotor && this.polarity == 0 ? -1 : 1));
+            return Math.round(this.speed * (!this._synchedMotor && this.polarityFactor()));
         }
 
         getAngle() {
@@ -90,6 +90,10 @@ namespace pxsim {
                 1 : Motor will run forward             
             */
             this.polarity = polarity;
+        }
+
+        private polarityFactor() {
+            return this.polarity == 0 ? -1 : 1;
         }
 
         reset() {
@@ -152,7 +156,7 @@ namespace pxsim {
                     case DAL.opOutputStepPower:
                     case DAL.opOutputStepSpeed: {
                         // ramp up, run, ramp down, <brake> using time
-                        const speed = this.speedCmdValues[0];
+                        const speed = this.speedCmdValues[0] * this.polarityFactor();
                         const step1 = this.speedCmdValues[1];
                         const step2 = this.speedCmdValues[2];
                         const step3 = this.speedCmdValues[3];
@@ -192,7 +196,7 @@ namespace pxsim {
                     case DAL.opOutputStepSync:
                     case DAL.opOutputTimeSync: {
                         const otherMotor = this._synchedMotor;
-                        const speed = this.speedCmdValues[0];
+                        const speed = this.speedCmdValues[0] * this.polarityFactor();
                         const turnRatio = this.speedCmdValues[1];
                         // if turnratio is negative, right motor at power level
                         // right motor -> this.port > otherMotor.port

--- a/sim/state/output.ts
+++ b/sim/state/output.ts
@@ -119,11 +119,7 @@ namespace pxsim {
                             return 2;
                         }
                         case DAL.opOutputPolarity: {
-                            // reverse
-                            const port = buf.data[1];
-                            const polarity = pxsim.BufferMethods.getNumber(buf, BufferMethods.NumberFormat.Int8LE, 2);
-                            const motors = ev3board().getMotor(port);
-                            motors.forEach(motor => motor.setPolarity(polarity));
+                            console.error("opOutputPolarity not supported");
                             return 2;
                         }
                         case DAL.opOutputSetType: {


### PR DESCRIPTION
the LEGO firmware is inconsistent w.r.t. to polarity support. Implement support in typescript instead.
- [x] test sim
- [x] test hw
```
brick.buttonEnter.onEvent(ButtonEvent.Pressed, function () {
    motors.stopAll()
})
brick.buttonLeft.onEvent(ButtonEvent.Pressed, function () {
    motors.largeB.setInverted(false)
    motors.largeB.run(50)
})
brick.buttonUp.onEvent(ButtonEvent.Pressed, function () {
    motors.largeBC.setInverted(false)
    motors.largeBC.run(50)
    pause(1000)
    motors.largeBC.steer(0, 50)
})
brick.buttonRight.onEvent(ButtonEvent.Pressed, function () {
    motors.largeB.setInverted(true)
    motors.largeB.run(50)
})
brick.buttonDown.onEvent(ButtonEvent.Pressed, function () {
    motors.largeBC.setInverted(true)
    motors.largeBC.run(50)
    pause(1000)
    motors.largeBC.steer(0, 50)
})
```