### PR TITLE
Change card type for 'Stop at Object'

### DIFF
--- a/docs/tutorials/touch-sensor.md
+++ b/docs/tutorials/touch-sensor.md
@@ -18,7 +18,7 @@
 }, {
   "name": "Stop At Object",
   "description": "Waits for the sensor to be pressed before continuing the program",
-  "cardType": "tutorial",
+  "cardType": "example",
   "url":"/tutorials/stop-at-object",
   "imageUrl":"/static/tutorials/pause-until-pressed.png"
 }]


### PR DESCRIPTION
The "Stop at Object" page isn't formatted as a tutorial. So, change it's card type to `example` or make it into a tutorial?

Some history here:

https://github.com/microsoft/pxt-ev3/commits/master/docs/tutorials/touch-sensor.md