### PR TITLE
Change timeout 1s -> 5s to reduce Timeout errors

### DIFF
--- a/editor/wrap.ts
+++ b/editor/wrap.ts
@@ -116,7 +116,7 @@ export class Ev3Wrapper {
             if (this.dataDump)
                 log("TALK: " + U.toHex(buf))
             return this.io.sendPacketAsync(buf)
-                .then(() => this.msgs.shiftAsync(1000))
+                .then(() => this.msgs.shiftAsync(5000))
                 .then(resp => {
                     if (resp[2] != buf[2] || resp[3] != buf[3])
                         U.userError("msg count de-sync")


### PR DESCRIPTION
I'm seeing lot of timeout errors when trying to send project via bluetooth. In most cases they occur at second and consecutives tries. Changing timeout to 5s eliminated this issues completely. I'm not sure if this is an issue with some slowness on my PC or my brick, but 5s still seems resonable to remove false positives. I did not encounter any errors after changing timeout value.