### PR TITLE
Add TS types for Serial object

### DIFF
--- a/editor/deploy.ts
+++ b/editor/deploy.ts
@@ -12,43 +12,6 @@ export function debug() {
         .then(w => w.downloadFileAsync("/tmp/dmesg.txt", v => console.log(pxt.Util.uint8ArrayToString(v))))
 }
 
-// Web Serial API https://wicg.github.io/serial/
-// chromium bug https://bugs.chromium.org/p/chromium/issues/detail?id=884928
-// Under experimental features in Chrome Desktop 77+
-enum ParityType {
-    "none",
-    "even",
-    "odd",
-    "mark",
-    "space"
-}
-declare interface SerialOptions {
-    baudrate?: number;
-    databits?: number;
-    stopbits?: number;
-    parity?: ParityType;
-    buffersize?: number;
-    rtscts?: boolean;
-    xon?: boolean;
-    xoff?: boolean;
-    xany?: boolean;
-}
-type SerialPortInfo = pxt.Map<string>;
-type SerialPortRequestOptions = any;
-declare class SerialPort {
-    open(options?: SerialOptions): Promise<void>;
-    close(): void;
-    readonly readable: any;
-    readonly writable: any;
-    //getInfo(): SerialPortInfo;
-}
-declare interface Serial extends EventTarget {
-    onconnect: any;
-    ondisconnect: any;
-    getPorts(): Promise<SerialPort[]>
-    requestPort(options: SerialPortRequestOptions): Promise<SerialPort>;
-}
-
 class WebSerialPackageIO implements pxt.HF2.PacketIO {
     onData: (v: Uint8Array) => void;
     onError: (e: Error) => void;
@@ -83,16 +46,15 @@ class WebSerialPackageIO implements pxt.HF2.PacketIO {
     }
 
     static isSupported(): boolean {
-        return !!(<any>navigator).serial;
+        return !!navigator.serial;
     }
 
     static portIos: WebSerialPackageIO[] = [];
     static async mkPacketIOAsync(): Promise<pxt.HF2.PacketIO> {
-        const serial = (<any>navigator).serial;
+        const serial = navigator.serial;
         if (serial) {
             try {
-                const requestOptions: SerialPortRequestOptions = {};
-                const port = await serial.requestPort(requestOptions);
+                const port = await serial.requestPort();
 
                 let io = WebSerialPackageIO.portIos.filter(i => i.port == port)[0];
                 if (!io) {

--- a/package.json
+++ b/package.json
@@ -32,17 +32,18 @@
     "docs/*/*/*.md"
   ],
   "devDependencies": {
-    "typescript": "2.6.1",
-    "react": "16.8.3",
-    "semantic-ui-less": "2.2.14",
     "@types/bluebird": "2.0.33",
+    "@types/dom-serial": "0.1.0",
+    "@types/jquery": "3.5.1",
     "@types/marked": "0.3.0",
     "@types/node": "8.0.53",
-    "webfonts-generator": "^0.4.0",
-    "@types/jquery": "3.2.16",
     "@types/react": "16.0.25",
     "@types/react-dom": "16.0.3",
-    "@types/web-bluetooth": "0.0.4"
+    "@types/web-bluetooth": "0.0.4",
+    "react": "16.8.3",
+    "semantic-ui-less": "2.2.14",
+    "typescript": "3.2.1",
+    "webfonts-generator": "^0.4.0"
   },
   "dependencies": {
     "pxt-common-packages": "6.18.2",


### PR DESCRIPTION
Replacing custom Serial types with @types package:

- added @types/dom-serial npm package
- bumped typescript version (needed for WritableStream DOM definition used in Serial)
- bumped jquery types version (conflicted with newer typescript)