### PR TITLE
fix invert motor angle metod

### DIFF
--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -597,7 +597,7 @@ namespace motors {
         //% help=motors/motor/angle
         angle(): number {
             this.init();
-            return getMotorData(this._port).count;
+            return getMotorData(this._port).count * this.invertedFactor();
         }
 
         /**


### PR DESCRIPTION
When set to reverse, the ange method does not return the correct value. The value is inverted.
For example, I connected two medium motors to the ev3 for the chassis.
One set the reverse. When I use propulsion techniques for motors, they spin correctly. But the one that, with reverse, gives angle with a minus, although the motor is spinning forward (as needed).

In my algorithm for moving along a line at a distance, ange () had to be multiplied by -1 for a motor with a reverse.