### PR TITLE
Fix music images items in other languages

### DIFF
--- a/fieldeditors/field_music.ts
+++ b/fieldeditors/field_music.ts
@@ -222,7 +222,7 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
             buttonImg.setAttribute('data-value', value);
             buttonImg.style.height = "auto";
             textNode.setAttribute('data-value', value);
-            //textNode.setAttribute('lang', "ru"); // for hyphens, here you need to set the correct abbreviation of the selected language 
+            textNode.setAttribute('lang', pxt.Util.userLanguage()); // for hyphens, here you need to set the correct abbreviation of the selected language 
             textNode.style.display = "block";
             textNode.style.lineHeight = "1rem";
             textNode.style.marginBottom = "5%";

--- a/fieldeditors/field_music.ts
+++ b/fieldeditors/field_music.ts
@@ -222,7 +222,7 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
             buttonImg.setAttribute('data-value', value);
             buttonImg.style.height = "auto";
             textNode.setAttribute('data-value', value);
-            textNode.setAttribute('lang', pxt.Util.userLanguage()); // for hyphens, here you need to set the correct abbreviation of the selected language 
+            if (pxt.Util.userLanguage() !== "en") textNode.setAttribute('lang', pxt.Util.userLanguage()); // for hyphens, here you need to set the correct abbreviation of the selected language 
             textNode.style.display = "block";
             textNode.style.lineHeight = "1rem";
             textNode.style.marginBottom = "5%";

--- a/fieldeditors/field_music.ts
+++ b/fieldeditors/field_music.ts
@@ -24,7 +24,7 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
         super(text, { blocksInfo: options.blocksInfo, sort: true, data: options.data }, validator);
 
         this.columns_ = parseInt(options.columns) || 4;
-        this.width_ = parseInt(options.width) || 380;
+        this.width_ = parseInt(options.width) || 450;
 
         this.setText = Blockly.FieldDropdown.prototype.setText;
         this.updateSize_ = (Blockly.Field as any).prototype.updateSize_;
@@ -58,6 +58,9 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
         contentDiv.setAttribute('role', 'menu');
         contentDiv.setAttribute('aria-haspopup', 'true');
         contentDiv.className = 'blocklyMusicFieldOptions';
+        contentDiv.style.display = "flex";
+        contentDiv.style.flexWrap = "wrap";
+        contentDiv.style.float = "none";
         const options = this.getOptions();
         //options.sort(); // Do not need to use to not apply sorting in different languages
 
@@ -128,6 +131,7 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
                 backgroundColor = '#0c4e5e';
                 button.setAttribute('aria-selected', 'true');
             }
+            button.style.padding = "2px 6px";
             button.style.backgroundColor = backgroundColor;
             button.style.borderColor = backgroundColor;
             Blockly.bindEvent_(button, 'click', this, this.categoryClick_);
@@ -217,7 +221,15 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
             const textNode = this.createTextNode_(content);
             button.setAttribute('data-value', value);
             buttonImg.setAttribute('data-value', value);
+            buttonImg.style.height = "auto";
             textNode.setAttribute('data-value', value);
+            //textNode.setAttribute('lang', "ru"); // for hyphens, here you need to set the correct abbreviation of the selected language 
+            textNode.style.display = "block";
+            textNode.style.lineHeight = "1rem";
+            textNode.style.marginBottom = "5%";
+            textNode.style.padding = "0px 8px";
+            textNode.style.wordBreak = "break-word";
+            textNode.style.hyphens = "auto";
 
             button.appendChild(buttonImg);
             button.appendChild(textNode);
@@ -244,7 +256,7 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
     protected createTextNode_(content: string) {
         const category = this.parseCategory(content);
         let text = content.substr(content.indexOf(' ') + 1);
-        text = text.length > 15 ? text.substr(0, 12) + "..." : text;
+        
         const textSpan = document.createElement('span');
         textSpan.setAttribute('class', 'blocklyDropdownText');
         textSpan.textContent = text;

--- a/fieldeditors/field_music.ts
+++ b/fieldeditors/field_music.ts
@@ -34,8 +34,7 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
         }
         if (!soundIconCache) {
             soundIconCache = JSON.parse(pxtTargetBundle.bundledpkgs['music']['icons.jres']);
-            soundIconCacheArray = Object.entries(soundIconCache);
-            soundIconCacheArray.shift(); // Delete first elem
+            soundIconCacheArray = Object.entries(soundIconCache).filter(el => el[0] !== "*");
         }
     }
 

--- a/fieldeditors/field_music.ts
+++ b/fieldeditors/field_music.ts
@@ -11,6 +11,7 @@ declare const pxtTargetBundle: any;
 
 let soundCache: any;
 let soundIconCache: any;
+let soundIconCacheArray: any;
 
 export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldCustom {
     public isFieldCustom_ = true;
@@ -33,6 +34,8 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
         }
         if (!soundIconCache) {
             soundIconCache = JSON.parse(pxtTargetBundle.bundledpkgs['music']['icons.jres']);
+            soundIconCacheArray = Object.entries(soundIconCache);
+            soundIconCacheArray.shift(); // Delete first elem
         }
     }
 
@@ -56,7 +59,7 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
         contentDiv.setAttribute('aria-haspopup', 'true');
         contentDiv.className = 'blocklyMusicFieldOptions';
         const options = this.getOptions();
-        options.sort();
+        //options.sort(); // Do not need to use to not apply sorting in different languages
 
         // Create categoies
         const categories = this.getCategories(options);
@@ -138,7 +141,7 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
     }
 
     refreshOptions(contentDiv: Element, options: any) {
-
+        const categories = this.getCategories(options);
         // Show options
         for (let i = 0, option: any; option = options[i]; i++) {
             let content = (options[i] as any)[0]; // Human-readable text or image.
@@ -202,9 +205,13 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
                 this.setAttribute('class', 'blocklyDropDownButton');
                 contentDiv.removeAttribute('aria-activedescendant');
             });
+
+            // Find index in array by category name
+            const categoryIndex = categories.indexOf(category);
+
             let buttonImg = document.createElement('img');
-            buttonImg.src = this.getSoundIcon(category);
-            //buttonImg.alt = icon.alt;
+            buttonImg.src = this.getSoundIcon(categoryIndex);
+
             // Upon click/touch, we will be able to get the clicked element as e.target
             // Store a data attribute on all possible click targets so we can match it to the icon.
             const textNode = this.createTextNode_(content);
@@ -305,9 +312,9 @@ export class FieldMusic extends pxtblockly.FieldImages implements Blockly.FieldC
         pxsim.AudioContextManager.stop();
     }
 
-    private getSoundIcon(category: string) {
-        if (soundIconCache && soundIconCache[category]) {
-            return soundIconCache[category].icon;
+    private getSoundIcon(indexCategory: number) {
+        if (soundIconCacheArray && soundIconCacheArray[indexCategory]) {
+            return soundIconCacheArray[indexCategory][1].icon;
         }
         return undefined;
     }


### PR DESCRIPTION
The problem has existed for a long time, icons for elements with music are not displayed.
If you look, then in Russian an undenfined error appears in the console.
```buttonImg.src = this.getSoundIcon(category);```

Here are some examples. English language.
![image](https://user-images.githubusercontent.com/13646226/234834087-1c1776a8-0925-4bb5-9301-ceb598776ca2.png)

That's it in Russian.
![image](https://user-images.githubusercontent.com/13646226/234834318-3b3ebf97-e627-4c7b-9710-8d783457e30b.png)
(These are pictures from the beta version.)

The problem was that if you enable another language on the site (for example, Russian), then the options values were taken with a translation in the selected language. They didn't match the category values (in English) in icons.jres.

1) Therefore, I decided to change it so that options sorting is disabled so that options do not change places in different languages.

2) Next, I from the initially obtained values
```soundIconCache = JSON.parse(pxtTargetBundle.bundledpkgs['music']['icons.jres']);```

![image](https://user-images.githubusercontent.com/13646226/234831710-d35faa97-7bf1-4fcf-be47-7d19ff35cfb4.png)

I recycle the object so that all elements are with indices
```soundIconCacheArray = Object.entries(soundIconCache);```

I remove the first element from my array, it is not needed. Interferes.
```soundIconCacheArray.shift();```

3) In the refreshOptions function, I first get all the categories.
```const categories = this.getCategories(options);```
Then I look up the index in the array with all the categories of the category element
```const categoryIndex = categories.indexOf(category);```

Further, to set the picture for the musical element, I pass this index to getSoundIcon.
```buttonImg.src = this.getSoundIcon(categoryIndex);```

4) I rewrote the getSoundIcon function itself so that it takes an icon from my earlier soundIconCacheArray by index.


I checked in several languages. The changes are working.
As a result, we get this...
![image](https://user-images.githubusercontent.com/13646226/234834585-bd942b1d-febc-44af-9b05-8f93a531b97a.png)
