### PR TITLE
Return background color of selected element in editor toggle

### DIFF
--- a/theme/style.less
+++ b/theme/style.less
@@ -92,6 +92,11 @@
     color: white;
 }
 
+/* active toggle */
+.ui.item.editor-menuitem .active~.item.toggle {
+    background: @editorToggleColor!important;
+}
+
 .menubar .ui.item.editor-menuitem .item.toggle {
     height: 45px;
 }


### PR DESCRIPTION
Return the background color of the selected element in the editor toggle.

It was before the change...
![image](https://user-images.githubusercontent.com/13646226/235069134-c82bfaa4-9d7c-4e10-99e3-279205ab12d4.png)

After changing...
![image](https://user-images.githubusercontent.com/13646226/235069167-23791471-3564-4be3-a216-69da34958d68.png)