### PR TITLE
Added support for Reflection Raw mode for the color sensor to the simulator

### DIFF
--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -250,7 +250,7 @@ namespace sensors {
         }
 
         /**
-         * Measure the ambient or reflected light value from 0 (darkest) to 100 (brightest).
+         * Measure the ambient or reflected light value from 0 (darkest) to 100 (brightest). In raw reflection light mode, the range will be different.
          * @param sensor the color sensor port
          */
         //% help=sensors/color-sensor/light

--- a/sim/state/color.ts
+++ b/sim/state/color.ts
@@ -21,7 +21,7 @@ namespace pxsim {
     export class ColorSensorNode extends UartSensorNode {
         id = NodeType.ColorSensor;
 
-        private color: number = 50;
+        private color: number = 0;
 
         constructor(port: number) {
             super(port);
@@ -39,6 +39,14 @@ namespace pxsim {
 
         getValue() {
             return this.color;
+        }
+
+        setMode(mode: number) {
+            this.mode = mode;
+            if (this.mode == ColorSensorMode.RefRaw) this.color = 512; 
+            else this.color = 50;
+            this.changed = true;
+            this.modeChanged = true;
         }
     }
 }

--- a/sim/visuals/board.ts
+++ b/sim/visuals/board.ts
@@ -241,6 +241,8 @@ namespace pxsim.visuals {
                         view = new ColorGridControl(this.element, this.defs, state, port);
                     } else if (state.getMode() == ColorSensorMode.Reflected) {
                         view = new ColorWheelControl(this.element, this.defs, state, port);
+                    } else if (state.getMode() == ColorSensorMode.RefRaw) {
+                        view = new ColorWheelControl(this.element, this.defs, state, port);
                     } else if (state.getMode() == ColorSensorMode.Ambient) {
                         view = new ColorWheelControl(this.element, this.defs, state, port);
                     }

--- a/sim/visuals/nodes/colorSensorView.ts
+++ b/sim/visuals/nodes/colorSensorView.ts
@@ -29,6 +29,7 @@ namespace pxsim.visuals {
             switch (mode) {
                 case ColorSensorMode.Colors: this.updateSensorLightVisual('#0062DD'); return; // blue
                 case ColorSensorMode.Reflected: this.updateSensorLightVisual('#F86262'); return; // red
+                case ColorSensorMode.RefRaw: this.updateSensorLightVisual('#F86262'); return; // red
                 case ColorSensorMode.Ambient: this.updateSensorLightVisual('#67C3E2'); return; // light blue
             }
             this.updateSensorLightVisual('#ffffff');


### PR DESCRIPTION
Code that adds reflection raw support for the color sensor. The range of values for this is from 0 to 1023, because analog to digital converter is 10 bits. In fact, the color sensor gives values ​​of about 400 - 700, but I decided to leave the range, which could theoretically be. For other cases (reflections and ambient lighting), the range remains from 0 to 100. The average value when setting the mode in the simulator is displayed as 512, for other modes 50%.