### PR TITLE
Extended show screen blocks options

### DIFF
--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -133,7 +133,7 @@ namespace brick {
      * @param column the column number to print the text at (starting at 1), eg: 1
      * @param printStyle print style black on white or white on black
      */
-    //% blockId=screenPrintNumber block="show number %name|at line %line||and column %column|with style %printStyle"
+    //% blockId=screenPrintNumber block="show number $value|at line $line||column $column|style $printStyle"
     //% weight=97 group="Screen" inlineInputMode="inline" blockGap=8
     //% expandableArgumentMode="enabled"
     //% help=brick/show-number

--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -66,28 +66,6 @@ namespace brick {
     }
 
     /**
-     * Clear on the screen at a specific line.
-     * @param line the line number to clear at (starting at 1), eg: 1
-     */
-    //% blockId=clearLine block="clear line %line"
-    //% weight=95 group="Screen" inlineInputMode="inline" blockGap=8
-    //% line.min=1 line.max=12
-    export function clearLine(line: number) {
-        if (screenMode != ScreenMode.ShowLines) {
-            screenMode = ScreenMode.ShowLines;
-            screen.fill(0);
-        }
-
-        line = (line - 1) >> 0; // line indexing starts at 1
-        const nlines = lineCount();
-        if (line < 0 || line > nlines) return; // out of screen by line
-
-        const h = lineHeight();
-        const y = textOffset + h * line;
-        screen.fillRect(0, y, screen.width, h, 0); // clear background
-    }
-
-    /**
      * Show text on the screen on a specific line and starting at a column and the selected print style.
      * @param text the text to print on the screen, eg: "Hello world"
      * @param line the line number to print the text at (starting at 1), eg: 1
@@ -156,7 +134,7 @@ namespace brick {
      * @param printStyle print style black on white or white on black
      */
     //% blockId=screenPrintNumber block="show number %name|at line %line||and column %column|with style %printStyle"
-    //% weight=96 group="Screen" inlineInputMode="inline" blockGap=8
+    //% weight=97 group="Screen" inlineInputMode="inline" blockGap=8
     //% expandableArgumentMode="enabled"
     //% help=brick/show-number
     //% line.min=1 line.max=12
@@ -171,7 +149,7 @@ namespace brick {
      * @param line the line number to print the text at, eg: 1
      */
     //% blockId=screenShowNumber block="show number %name|at line %line"
-    //% weight=96 group="Screen" inlineInputMode="inline" blockGap=8
+    //% weight=97 group="Screen" inlineInputMode="inline" blockGap=8
     //% help=brick/show-number
     //% line.min=1 line.max=12
     //% deprecated=true
@@ -235,7 +213,7 @@ namespace brick {
     */
     //% blockId=brickShowPorts block="show ports"
     //% help=brick/show-ports blockGap=8
-    //% weight=10 group="Screen"
+    //% weight=95 group="Screen"
     export function showPorts() {
         if (screenMode == ScreenMode.Ports) return;
 
@@ -323,10 +301,32 @@ namespace brick {
     }
 
     /**
+     * Clear on the screen at a specific line.
+     * @param line the line number to clear at (starting at 1), eg: 1
+     */
+    //% blockId=clearLine block="clear line %line"
+    //% weight=94 group="Screen" inlineInputMode="inline" blockGap=8
+    //% line.min=1 line.max=12
+    export function clearLine(line: number) {
+        if (screenMode != ScreenMode.ShowLines) {
+            screenMode = ScreenMode.ShowLines;
+            screen.fill(0);
+        }
+
+        line = (line - 1) >> 0; // line indexing starts at 1
+        const nlines = lineCount();
+        if (line < 0 || line > nlines) return; // out of screen by line
+
+        const h = lineHeight();
+        const y = textOffset + h * line;
+        screen.fillRect(0, y, screen.width, h, 0); // clear background
+    }
+
+    /**
      * Clear the screen
      */
     //% blockId=screen_clear_screen block="clear screen"
-    //% weight=90 group="Screen"
+    //% weight=93 group="Screen"
     //% help=brick/clear-screen weight=1
     export function clearScreen() {
         screen.fill(0)

--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -304,7 +304,7 @@ namespace brick {
      * Clear on the screen at a specific line.
      * @param line the line number to clear at (starting at 1), eg: 1
      */
-    //% blockId=clearLine block="clear line %line"
+    //% blockId=clearLine block="clear line $line"
     //% weight=94 group="Screen" inlineInputMode="inline" blockGap=8
     //% line.min=1 line.max=12
     export function clearLine(line: number) {

--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -72,7 +72,7 @@ namespace brick {
      * @param column the column number to print the text at (starting at 1), eg: 1
      * @param printStyle print style black on white or white on black
      */
-    //% blockId=screenPrintString block="show string %text|at line %line||and column %column|with style %printStyle"
+    //% blockId=screenPrintString block="show string $text|at line $line||column $column|style $printStyle"
     //% weight=98 group="Screen" inlineInputMode="inline" blockGap=8
     //% expandableArgumentMode="enabled"
     //% help=brick/show-string

--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -165,7 +165,7 @@ namespace brick {
      * @param column the column number to print the text at (starting at 1), eg: 1
      * @param printStyle print style black on white or white on black
      */
-    //% blockId=screenPrintValue block="show value %name|= %text|at line %line||and column %column|with style %printStyle"
+    //% blockId=screenPrintValue block="show value $name|= $value|at line $line||column $column|style $printStyle"
     //% weight=96 group="Screen" inlineInputMode="inline" blockGap=8
     //% expandableArgumentMode="enabled"
     //% help=brick/show-value

--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -22,6 +22,7 @@ namespace _screen_internal {
 namespace brick {
     const textOffset = 4;
     const lineOffset = 2;
+
     enum ScreenMode {
         None,
         ShowLines,
@@ -29,6 +30,14 @@ namespace brick {
         Ports,
         Custom
     }
+
+    export enum PrintStyle {
+        //% block="black on white"
+        BlackOnWhite,
+        //% block="white on black"
+        WhiteOnBlack
+    }
+
     let screenMode = ScreenMode.None;
     export let font = image.font8;
 
@@ -49,6 +58,70 @@ namespace brick {
     }
 
     /**
+     * Number of columns
+     */
+    //%
+    export function columnCount(): number {
+        return ((screen.width - textOffset) / font.charWidth) >> 0
+    }
+
+    /**
+     * Clear on the screen at a specific line.
+     * @param line the line number to clear at (starting at 1), eg: 1
+     */
+    //% blockId=clearLine block="clear line %line"
+    //% weight=95 group="Screen" inlineInputMode="inline" blockGap=8
+    //% line.min=1 line.max=12
+    export function clearLine(line: number) {
+        if (screenMode != ScreenMode.ShowLines) {
+            screenMode = ScreenMode.ShowLines;
+            screen.fill(0);
+        }
+
+        line = (line - 1) >> 0; // line indexing starts at 1
+        const nlines = lineCount();
+        if (line < 0 || line > nlines) return; // out of screen by line
+
+        const h = lineHeight();
+        const y = textOffset + h * line;
+        screen.fillRect(0, y, screen.width, h, 0); // clear background
+    }
+
+    /**
+     * Show text on the screen on a specific line and starting at a column and the selected print style.
+     * @param text the text to print on the screen, eg: "Hello world"
+     * @param line the line number to print the text at (starting at 1), eg: 1
+     * @param column the column number to print the text at (starting at 1), eg: 1
+     * @param printStyle print style black on white or white on black
+     */
+    //% blockId=screenPrintString block="show string %text|at line %line||and column %column|with style %printStyle"
+    //% weight=98 group="Screen" inlineInputMode="inline" blockGap=8
+    //% expandableArgumentMode="enabled"
+    //% help=brick/show-string
+    //% line.min=1 line.max=12
+    //% column.min=1 column.max=29
+    export function printString(text: string, line: number, column: number = 1, printStyle: PrintStyle = PrintStyle.BlackOnWhite) {
+        if (screenMode != ScreenMode.ShowLines) {
+            screenMode = ScreenMode.ShowLines;
+            screen.fill(0);
+        }
+
+        line = (line - 1) >> 0; // line indexing starts at 1
+        column = (column - 1) >> 0; // column indexing starts at 1
+        const nlines = lineCount();
+        const nColumn = columnCount();
+        if (line < 0 || line > nlines) return; // out of screen by line
+        if (column < 0 || column > nColumn) return; // out of screen by column
+        
+        const w = font.charWidth;
+        const h = lineHeight();
+        const x = textOffset + w * column;
+        const y = textOffset + h * line;
+        screen.fillRect(x, y, text.length * font.charWidth, h, (printStyle == PrintStyle.BlackOnWhite ? 0 : 255)); // clear background
+        screen.print(text, x, y, (printStyle == PrintStyle.BlackOnWhite ? 1 : 2), font);
+    }
+
+    /**
      * Show text on the screen at a specific line.
      * @param text the text to print on the screen, eg: "Hello world"
      * @param line the line number to print the text at (starting at 1), eg: 1
@@ -56,7 +129,8 @@ namespace brick {
     //% blockId=screen_print block="show string %text|at line %line"
     //% weight=98 group="Screen" inlineInputMode="inline" blockGap=8
     //% help=brick/show-string
-    //% line.min=1 line.max=10
+    //% line.min=1 line.max=12
+    //% deprecated=true
     export function showString(text: string, line: number) {
         if (screenMode != ScreenMode.ShowLines) {
             screenMode = ScreenMode.ShowLines;
@@ -75,6 +149,23 @@ namespace brick {
     }
 
     /**
+     * Show a number on the screen on a specific line and starting at a column and the selected print style.
+     * @param value the numeric value
+     * @param line the line number to print the text at, eg: 1
+     * @param column the column number to print the text at (starting at 1), eg: 1
+     * @param printStyle print style black on white or white on black
+     */
+    //% blockId=screenPrintNumber block="show number %name|at line %line||and column %column|with style %printStyle"
+    //% weight=96 group="Screen" inlineInputMode="inline" blockGap=8
+    //% expandableArgumentMode="enabled"
+    //% help=brick/show-number
+    //% line.min=1 line.max=12
+    //% column.min=1 column.max=29
+    export function printNumber(value: number, line: number, column: number = 1, printStyle: PrintStyle = PrintStyle.BlackOnWhite) {
+        printString("" + value, line, column, printStyle);
+    }
+
+    /**
      * Show a number on the screen
      * @param value the numeric value
      * @param line the line number to print the text at, eg: 1
@@ -82,9 +173,29 @@ namespace brick {
     //% blockId=screenShowNumber block="show number %name|at line %line"
     //% weight=96 group="Screen" inlineInputMode="inline" blockGap=8
     //% help=brick/show-number
-    //% line.min=1 line.max=10
+    //% line.min=1 line.max=12
+    //% deprecated=true
     export function showNumber(value: number, line: number) {
         showString("" + value, line);
+    }
+
+    /**
+     * Show a name, value pair on the screen on a specific line and starting at a column and the selected print style.
+     * @param name the value name
+     * @param value the numeric value
+     * @param line the line number to print the text at, eg: 1
+     * @param column the column number to print the text at (starting at 1), eg: 1
+     * @param printStyle print style black on white or white on black
+     */
+    //% blockId=screenPrintValue block="show value %name|= %text|at line %line||and column %column|with style %printStyle"
+    //% weight=96 group="Screen" inlineInputMode="inline" blockGap=8
+    //% expandableArgumentMode="enabled"
+    //% help=brick/show-value
+    //% line.min=1 line.max=12
+    //% column.min=1 column.max=29
+    export function printValue(name: string, value: number, line: number, column: number = 1, printStyle: PrintStyle = PrintStyle.BlackOnWhite) {
+        value = Math.round(value * 1000) / 1000;
+        printString((name ? name + ": " : "") + value, line, column, printStyle);
     }
 
     /**
@@ -95,7 +206,8 @@ namespace brick {
     //% blockId=screenShowValue block="show value %name|= %text|at line %line"
     //% weight=96 group="Screen" inlineInputMode="inline" blockGap=8
     //% help=brick/show-value
-    //% line.min=1 line.max=10
+    //% line.min=1 line.max=12
+    //% deprecated=true
     export function showValue(name: string, value: number, line: number) {
         value = Math.round(value * 1000) / 1000;
         showString((name ? name + ": " : "") + value, line);

--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -10,8 +10,8 @@ const screen = image.create(DAL.LCD_WIDTH, DAL.LCD_HEIGHT)
 namespace _screen_internal {
     //% shim=pxt::updateScreen
     function updateScreen(img: Image): void { }
-    function updateStats(msg: string): void { }
     //% shim=pxt::updateStats
+    function updateStats(msg: string): void { }
 
     control.__screen.setupUpdate(() => updateScreen(screen))
     control.EventContext.onStats = function (msg: string) {


### PR DESCRIPTION
Similar blocks have been created, in which the ability to select the place to print horizontally (columns) has been added, as well as the choice of printing mode black text on a white background and white text on a black background.

Old blocks are deprecated.