### PR TITLE
Сhange gray to brown in simulator circle class

### DIFF
--- a/sim/visuals/controls/colorGrid.ts
+++ b/sim/visuals/controls/colorGrid.ts
@@ -5,7 +5,7 @@ namespace pxsim.visuals {
     export class ColorGridControl extends ControlView<ColorSensorNode> {
         private group: SVGGElement;
 
-        private static colorIds = ['red', 'yellow', 'blue', 'green', 'black', 'grey', 'white', 'none'];
+        private static colorIds = ['red', 'yellow', 'blue', 'green', 'black', 'brown', 'white', 'none'];
         private static colorValue = [5, 4, 2, 3, 1, 7, 6, 0];
 
         private colorDivs: Element[] = [];
@@ -15,7 +15,7 @@ namespace pxsim.visuals {
             this.group.setAttribute("transform", `translate(2, 2.5) scale(0.6)`)
 
             const colors = ['#f12a21', '#ffd01b', '#006db3', '#00934b', '#000', '#6c2d00'];
-            const colorIds = ['red', 'yellow', 'blue', 'green', 'black', 'grey'];
+            const colorIds = ['red', 'yellow', 'blue', 'green', 'black', 'brown'];
 
             let cy = -4;
             for (let c = 0; c < colorIds.length; c++) {


### PR DESCRIPTION
A typo that hadn't been noticed before. Does not affect the operation of the simulator.

before
![Screenshot_1](https://user-images.githubusercontent.com/13646226/236618881-8c1526a5-7167-4b48-83bd-b47804f50b93.jpg)