### PR TITLE
RGB raw color sensor simulator support

### DIFF
--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -87,9 +87,16 @@ namespace sensors {
                 || this.mode == ColorSensorMode.AmbientLightIntensity
                 || this.mode == ColorSensorMode.ReflectedLightIntensity)
                 return this.getNumber(NumberFormat.UInt8LE, 0)
-            if (this.mode == ColorSensorMode.RefRaw || this.mode == ColorSensorMode.RgbRaw)
+            if (this.mode == ColorSensorMode.RefRaw)
                 return this.getNumber(NumberFormat.UInt16LE, 0)
             return 0
+        }
+
+        _queryArr(): number[] {
+            if (this.mode == ColorSensorMode.RgbRaw) {
+                return [this.getNumber(NumberFormat.UInt16LE, 0), this.getNumber(NumberFormat.UInt16LE, 2), this.getNumber(NumberFormat.UInt16LE, 4)];
+            }
+            return [0, 0, 0];
         }
 
         _info(): string {
@@ -106,8 +113,20 @@ namespace sensors {
                 case ColorSensorMode.AmbientLightIntensity:
                 case ColorSensorMode.ReflectedLightIntensity:
                     return `${this._query()}%`;
+                case ColorSensorMode.RgbRaw:
+                    return "array";
                 default:
                     return this._query().toString();
+            }
+        }
+
+        _infoArr(): string[] {
+            switch (this.mode) {
+                case ColorSensorMode.RgbRaw:
+                    const queryArr = this._queryArr().map(number => number.toString());
+                    return queryArr;
+                default:
+                    return ["0", "0", "0"];
             }
         }
 

--- a/libs/core/input.ts
+++ b/libs/core/input.ts
@@ -400,6 +400,10 @@ void      cUiUpdatePower(void)
             return this._query().toString();
         }
 
+        _infoArr(): string[] {
+            return [this._query().toString()];
+        }
+
         _update(prev: number, curr: number) {
         }
 

--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -272,7 +272,14 @@ namespace brick {
             const x = (si.port() - 1) * col + 2;
             const inf = si._info();
             if (screenMode != ScreenMode.Ports) return;
-            if (inf) screen.print(inf, x, h - 2 * lineHeight8, 1, inf.length > 4 ? image.font5 : image.font8);
+            if (inf == "array") {
+                let infArr = si._infoArr();
+                for (let data = 0, str = Math.min(infArr.length + 1, 4); data < Math.min(infArr.length, 3); data++, str--) {
+                    screen.print(infArr[data], x, h - str * lineHeight8, 1, infArr[data].length > 4 ? image.font5 : image.font8);
+                }
+            } else if (inf) {
+                screen.print(inf, x, h - 2 * lineHeight8, 1, inf.length > 4 ? image.font5 : image.font8);
+            }
         }
     }
 

--- a/sim/dalboard.ts
+++ b/sim/dalboard.ts
@@ -151,7 +151,7 @@ namespace pxsim {
             return !!this.inputNodes[port];
         }
 
-        getSensor(port: number, type: number): SensorNode | SensorExtendedNode {
+        getSensor(port: number, type: number): SensorNode {
             if (!this.inputNodes[port]) {
                 switch (type) {
                     case DAL.DEVICE_TYPE_GYRO: this.inputNodes[port] = new GyroSensorNode(port); break;
@@ -189,7 +189,6 @@ namespace pxsim {
     }
 
     export function inHighcontrastMode(): boolean {
-        ///
         return ev3board().highcontrastMode;
     }
 

--- a/sim/dalboard.ts
+++ b/sim/dalboard.ts
@@ -151,7 +151,7 @@ namespace pxsim {
             return !!this.inputNodes[port];
         }
 
-        getSensor(port: number, type: number): SensorNode {
+        getSensor(port: number, type: number): SensorNode | SensorExtendedNode {
             if (!this.inputNodes[port]) {
                 switch (type) {
                     case DAL.DEVICE_TYPE_GYRO: this.inputNodes[port] = new GyroSensorNode(port); break;
@@ -189,7 +189,7 @@ namespace pxsim {
     }
 
     export function inHighcontrastMode(): boolean {
-        ////
+        ///
         return ev3board().highcontrastMode;
     }
 

--- a/sim/dalboard.ts
+++ b/sim/dalboard.ts
@@ -189,6 +189,7 @@ namespace pxsim {
     }
 
     export function inHighcontrastMode(): boolean {
+        ////
         return ev3board().highcontrastMode;
     }
 

--- a/sim/state/color.ts
+++ b/sim/state/color.ts
@@ -21,7 +21,9 @@ namespace pxsim {
     export class ColorSensorNode extends UartSensorNode {
         id = NodeType.ColorSensor;
 
+        //private colors: number[] = [0];
         private color: number = 0;
+        private colors: number[] = [0, 0, 0];
 
         constructor(port: number) {
             super(port);
@@ -32,8 +34,13 @@ namespace pxsim {
             return DAL.DEVICE_TYPE_COLOR;
         }
 
-        setColor(color: number) {
-            this.color = color;
+        setColors(colors: number[]) {
+            this.colors = colors;
+            this.setChangedState();
+        }
+
+        setColor(colors: number) {
+            this.colors = [colors];
             this.setChangedState();
         }
 
@@ -41,10 +48,15 @@ namespace pxsim {
             return this.color;
         }
 
+        getValues() {
+            return this.colors;
+        }
+
         setMode(mode: number) {
             this.mode = mode;
-            if (this.mode == ColorSensorMode.RefRaw) this.color = 512; 
-            else this.color = 50;
+            if (this.mode == ColorSensorMode.RefRaw) this.color = 512;
+            else if (this.mode == ColorSensorMode.RgbRaw) this.colors = [128, 128, 128];
+            else this.color = 50; // Reflection or ambiend light
             this.changed = true;
             this.modeChanged = true;
         }

--- a/sim/state/color.ts
+++ b/sim/state/color.ts
@@ -43,8 +43,8 @@ namespace pxsim {
             this.setChangedState();
         }
 
-        setColor(colors: number) {
-            this.color = colors;
+        setColor(color: number) {
+            this.color = color;
             this.setChangedState();
         }
 
@@ -60,12 +60,15 @@ namespace pxsim {
             this.mode = mode;
             if (this.mode == ColorSensorMode.RefRaw) {
                 this.color = 512;
+                this.colors = [0, 0, 0];
                 this.modeReturnArr = false;
             } else if (this.mode == ColorSensorMode.RgbRaw) {
+                this.color = 0;
                 this.colors = [128, 128, 128];
                 this.modeReturnArr = true;
             } else { // Reflection or ambiend light
                 this.color = 50;
+                this.colors = [0, 0, 0];
                 this.modeReturnArr = false;
             }
             this.changed = true;

--- a/sim/state/color.ts
+++ b/sim/state/color.ts
@@ -21,17 +21,21 @@ namespace pxsim {
     export class ColorSensorNode extends UartSensorNode {
         id = NodeType.ColorSensor;
 
-        //private colors: number[] = [0];
         private color: number = 0;
         private colors: number[] = [0, 0, 0];
 
         constructor(port: number) {
             super(port);
             this.mode = -1;
+            this.modeReturnArr = false;
         }
 
         getDeviceType() {
             return DAL.DEVICE_TYPE_COLOR;
+        }
+
+        isModeReturnArr() {
+            return this.modeReturnArr;
         }
 
         setColors(colors: number[]) {
@@ -40,7 +44,7 @@ namespace pxsim {
         }
 
         setColor(colors: number) {
-            this.colors = [colors];
+            this.color = colors;
             this.setChangedState();
         }
 
@@ -54,9 +58,16 @@ namespace pxsim {
 
         setMode(mode: number) {
             this.mode = mode;
-            if (this.mode == ColorSensorMode.RefRaw) this.color = 512;
-            else if (this.mode == ColorSensorMode.RgbRaw) this.colors = [128, 128, 128];
-            else this.color = 50; // Reflection or ambiend light
+            if (this.mode == ColorSensorMode.RefRaw) {
+                this.color = 512;
+                this.modeReturnArr = false;
+            } else if (this.mode == ColorSensorMode.RgbRaw) {
+                this.colors = [128, 128, 128];
+                this.modeReturnArr = true;
+            } else { // Reflection or ambiend light
+                this.color = 50;
+                this.modeReturnArr = false;
+            }
             this.changed = true;
             this.modeChanged = true;
         }

--- a/sim/state/color.ts
+++ b/sim/state/color.ts
@@ -66,6 +66,10 @@ namespace pxsim {
                 this.color = 0;
                 this.colors = [128, 128, 128];
                 this.modeReturnArr = true;
+            } else if (this.mode == ColorSensorMode.Colors) {
+                this.color = 0; // None defl color
+                this.colors = [0, 0, 0];
+                this.modeReturnArr = false;
             } else { // Reflection or ambiend light
                 this.color = 50;
                 this.colors = [0, 0, 0];

--- a/sim/state/sensor.ts
+++ b/sim/state/sensor.ts
@@ -6,6 +6,7 @@ namespace pxsim {
         protected mode: number;
         protected valueChanged: boolean;
         protected modeChanged: boolean;
+        protected modeReturnArr: boolean;
 
         constructor(port: number) {
             super(port);
@@ -17,67 +18,17 @@ namespace pxsim {
 
         public isAnalog() {
             return false;
+        }
+
+        public isModeReturnArr() {
+            return this.modeReturnArr;
         }
 
         public getValue() {
             return 0;
         }
 
-        setMode(mode: number) {
-            this.mode = mode;
-            this.changed = true;
-            this.modeChanged = true;
-        }
-
-        getMode() {
-            return this.mode;
-        }
-
-        getDeviceType() {
-            return DAL.DEVICE_TYPE_NONE;
-        }
-
-        public hasData() {
-            return true;
-        }
-
-        valueChange() {
-            const res = this.valueChanged;
-            this.valueChanged = false;
-            return res;
-        }
-
-        modeChange() {
-            const res = this.modeChanged;
-            this.modeChanged = false;
-            return res;
-        }
-
-        setChangedState() {
-            this.changed = true;
-            this.valueChanged = false;
-        }
-    }
-
-    export class SensorExtendedNode extends BaseNode {
-
-        protected mode: number;
-        protected valueChanged: boolean;
-        protected modeChanged: boolean;
-
-        constructor(port: number) {
-            super(port);
-        }
-
-        public isUart() {
-            return true;
-        }
-
-        public isAnalog() {
-            return false;
-        }
-
-        public getValue() {
+        public getValues() {
             return [0];
         }
 
@@ -85,6 +36,7 @@ namespace pxsim {
             this.mode = mode;
             this.changed = true;
             this.modeChanged = true;
+            this.modeReturnArr = false;
         }
 
         getMode() {
@@ -140,21 +92,6 @@ namespace pxsim {
 
         hasChanged() {
             return this.changed;
-        }
-    }
-
-    export class UartSensorExtendedNode extends SensorNode {
-
-        constructor(port: number) {
-            super(port);
-        }
-
-        hasChanged() {
-            return this.changed;
-        }
-
-        public getValues() {
-            return [0];
         }
     }
 

--- a/sim/state/sensor.ts
+++ b/sim/state/sensor.ts
@@ -59,6 +59,64 @@ namespace pxsim {
         }
     }
 
+    export class SensorExtendedNode extends BaseNode {
+
+        protected mode: number;
+        protected valueChanged: boolean;
+        protected modeChanged: boolean;
+
+        constructor(port: number) {
+            super(port);
+        }
+
+        public isUart() {
+            return true;
+        }
+
+        public isAnalog() {
+            return false;
+        }
+
+        public getValue() {
+            return [0];
+        }
+
+        setMode(mode: number) {
+            this.mode = mode;
+            this.changed = true;
+            this.modeChanged = true;
+        }
+
+        getMode() {
+            return this.mode;
+        }
+
+        getDeviceType() {
+            return DAL.DEVICE_TYPE_NONE;
+        }
+
+        public hasData() {
+            return true;
+        }
+
+        valueChange() {
+            const res = this.valueChanged;
+            this.valueChanged = false;
+            return res;
+        }
+
+        modeChange() {
+            const res = this.modeChanged;
+            this.modeChanged = false;
+            return res;
+        }
+
+        setChangedState() {
+            this.changed = true;
+            this.valueChanged = false;
+        }
+    }
+
     export class AnalogSensorNode extends SensorNode {
 
         constructor(port: number) {
@@ -84,4 +142,20 @@ namespace pxsim {
             return this.changed;
         }
     }
+
+    export class UartSensorExtendedNode extends SensorNode {
+
+        constructor(port: number) {
+            super(port);
+        }
+
+        hasChanged() {
+            return this.changed;
+        }
+
+        public getValues() {
+            return [0];
+        }
+    }
+
 }

--- a/sim/state/uart.ts
+++ b/sim/state/uart.ts
@@ -91,13 +91,15 @@ namespace pxsim {
                         if (node && node.isUart()) {
                             // Actual
                             const index = 0; //UartOff.Actual + port * 2;
-                            //console.log(node.isModeReturnArr()); // Узнать возвращает ли режим датчика массив значений
-                            let value, values;
                             if (!node.isModeReturnArr()) {
-                                value = Math.floor(node.getValue());
+                                const value = Math.floor(node.getValue());
                                 util.map16Bit(data, UartOff.Raw + DAL.MAX_DEVICE_DATALENGTH * 300 * port + DAL.MAX_DEVICE_DATALENGTH * index, value);
-                            } else values = node.getValues();
-                            //util.map16Bit(data, UartOff.Raw + DAL.MAX_DEVICE_DATALENGTH * 300 * port + DAL.MAX_DEVICE_DATALENGTH * index, value);
+                            } else {
+                                const values = node.getValues();
+                                for (let i = 0, offset = 0; i < values.length; i++, offset += 2) {
+                                    util.map16Bit(data, UartOff.Raw + DAL.MAX_DEVICE_DATALENGTH * 300 * port + DAL.MAX_DEVICE_DATALENGTH * index + offset, Math.floor(values[i]));
+                                }
+                            }
                             // Status
                             data[UartOff.Status + port] = node.valueChange() ? UartStatus.UART_PORT_CHANGED : UartStatus.UART_DATA_READY;
                         }

--- a/sim/state/uart.ts
+++ b/sim/state/uart.ts
@@ -91,7 +91,13 @@ namespace pxsim {
                         if (node && node.isUart()) {
                             // Actual
                             const index = 0; //UartOff.Actual + port * 2;
-                            util.map16Bit(data, UartOff.Raw + DAL.MAX_DEVICE_DATALENGTH * 300 * port + DAL.MAX_DEVICE_DATALENGTH * index, Math.floor(node.getValue()))
+                            //console.log(node.isModeReturnArr()); // Узнать возвращает ли режим датчика массив значений
+                            let value, values;
+                            if (!node.isModeReturnArr()) {
+                                value = Math.floor(node.getValue());
+                                util.map16Bit(data, UartOff.Raw + DAL.MAX_DEVICE_DATALENGTH * 300 * port + DAL.MAX_DEVICE_DATALENGTH * index, value);
+                            } else values = node.getValues();
+                            //util.map16Bit(data, UartOff.Raw + DAL.MAX_DEVICE_DATALENGTH * 300 * port + DAL.MAX_DEVICE_DATALENGTH * index, value);
                             // Status
                             data[UartOff.Status + port] = node.valueChange() ? UartStatus.UART_PORT_CHANGED : UartStatus.UART_DATA_READY;
                         }

--- a/sim/state/uart.ts
+++ b/sim/state/uart.ts
@@ -92,12 +92,12 @@ namespace pxsim {
                             // Actual
                             const index = 0; //UartOff.Actual + port * 2;
                             if (!node.isModeReturnArr()) {
-                                const value = Math.floor(node.getValue());
+                                const value = Math.round(node.getValue());
                                 util.map16Bit(data, UartOff.Raw + DAL.MAX_DEVICE_DATALENGTH * 300 * port + DAL.MAX_DEVICE_DATALENGTH * index, value);
                             } else {
                                 const values = node.getValues();
                                 for (let i = 0, offset = 0; i < values.length; i++, offset += 2) {
-                                    util.map16Bit(data, UartOff.Raw + DAL.MAX_DEVICE_DATALENGTH * 300 * port + DAL.MAX_DEVICE_DATALENGTH * index + offset, Math.floor(values[i]));
+                                    util.map16Bit(data, UartOff.Raw + DAL.MAX_DEVICE_DATALENGTH * 300 * port + DAL.MAX_DEVICE_DATALENGTH * index + offset, Math.round(values[i]));
                                 }
                             }
                             // Status

--- a/sim/visuals/board.ts
+++ b/sim/visuals/board.ts
@@ -239,6 +239,8 @@ namespace pxsim.visuals {
                     const state = ev3board().getInputNodes()[port] as ColorSensorNode;
                     if (state.getMode() == ColorSensorMode.Colors) {
                         view = new ColorGridControl(this.element, this.defs, state, port);
+                    } else if (state.getMode() == ColorSensorMode.RgbRaw) {
+                        view = new ColorRGBWheelControl(this.element, this.defs, state, port);
                     } else if (state.getMode() == ColorSensorMode.Reflected) {
                         view = new ColorWheelControl(this.element, this.defs, state, port);
                     } else if (state.getMode() == ColorSensorMode.RefRaw) {

--- a/sim/visuals/controls/colorRGBWheel.ts
+++ b/sim/visuals/controls/colorRGBWheel.ts
@@ -33,7 +33,7 @@ namespace pxsim.visuals {
         }
 
         private getMaxValue() {
-            return 512;
+            return 511;
         }
 
         private mapValue(x: number, inMin: number, inMax: number, outMin: number, outMax: number) {
@@ -45,7 +45,7 @@ namespace pxsim.visuals {
             const node = this.state;
             const values = node.getValues();
             //console.log("values: ");
-            console.log(values);
+            //console.log(values);
             let inverseValue: number[] = [];
             for (let i = 0; i < 3; i++) {
                 inverseValue[i] = this.getMaxValue() - values[i];

--- a/sim/visuals/controls/colorRGBWheel.ts
+++ b/sim/visuals/controls/colorRGBWheel.ts
@@ -1,0 +1,165 @@
+namespace pxsim.visuals {
+
+    export class ColorRGBWheelControl extends ControlView<ColorSensorNode> {
+        private group: SVGGElement;
+        private colorGradient: SVGLinearGradientElement;
+        private reporter: SVGTextElement[] = [];
+        private rect: SVGElement[] = [];
+
+        private printOffsetH = 18;
+
+        getInnerWidth() {
+            return 120;
+        }
+
+        getInnerHeight() {
+            return 192;
+        }
+
+        private getReporterHeight() {
+            return 70;
+        }
+
+        private getSliderWidth() {
+            return 24;
+        }
+
+        private getSliderHeight() {
+            return 100;
+        }
+
+        private getMaxValue() {
+            return 1023;
+        }
+
+        private mapValue(x: number, inMin: number, inMax: number, outMin: number, outMax: number) {
+            return (x - inMin) * (outMax - outMin) / (inMax - inMin) + outMin;
+        }
+
+        updateState() {
+            if (!this.visible) return;
+            const node = this.state;
+            const value = node.getValue();
+            let inverseValue = this.getMaxValue() - value;
+            inverseValue = this.mapValue(inverseValue, 0, 1023, 0, 100);
+            svg.setGradientValue(this.colorGradient, inverseValue + "%");
+            this.reporter[0].textContent = "R: " + `${parseFloat((value).toString()).toFixed(0)}`;
+            this.reporter[1].textContent = "G: " + `${parseFloat((value).toString()).toFixed(0)}`;
+            this.reporter[2].textContent = "B: " + `${parseFloat((value).toString()).toFixed(0)}`;
+        }
+
+        updateColorLevel(pt: SVGPoint, parent: SVGSVGElement, ev: MouseEvent) {
+            let cur = svg.cursorPoint(pt, parent, ev);
+            const bBox = this.rect[0].getBoundingClientRect();
+            const height = bBox.height;
+            let t = Math.max(0, Math.min(1, (height + bBox.top / this.scaleFactor - cur.y / this.scaleFactor) / height));
+            const state = this.state;
+            state.setColor(t * this.getMaxValue());
+        }
+
+        getInnerView(parent: SVGSVGElement, globalDefs: SVGDefsElement) {
+            this.group = svg.elt("g") as SVGGElement;
+
+            let gc = "gradient-color-" + this.getPort();
+            const prevColorGradient = globalDefs.querySelector(`#${gc}`) as SVGLinearGradientElement;
+            this.colorGradient = prevColorGradient ? prevColorGradient : svg.linearGradient(globalDefs, gc, false);
+            svg.setGradientValue(this.colorGradient, "50%");
+            svg.setGradientColors(this.colorGradient, "black", "yellow");
+
+            let reporterGroup: SVGElement[] = [];
+            for (let i = 0; i < 3; i++) {
+                reporterGroup[i] = pxsim.svg.child(this.group, "g");
+
+                console.log(`reporterGroup[${i}]:`);
+                console.log(reporterGroup[i]);
+
+                reporterGroup[i].setAttribute("transform", `translate(${this.getWidth() / 2}, ${18 + this.printOffsetH * i})`);
+                this.reporter[i] = pxsim.svg.child(reporterGroup[i], "text", { 'text-anchor': 'middle', 'class': 'sim-text number large inverted', 'style': 'font-size: 18px;' }) as SVGTextElement;
+                
+                console.log(`this.reporter[${i}]:`);
+                console.log(this.reporter[0]);
+            }
+            
+            let sliderGroup: SVGElement[] = [];
+            for (let i = 0; i < 3; i++) {
+                sliderGroup[i] = pxsim.svg.child(this.group, "g");
+                const translateX = (this.getWidth() / 2 - this.getSliderWidth() / 2 - 36) + 36 * i;
+                sliderGroup[i].setAttribute("transform", `translate(${translateX}, ${this.getReporterHeight()})`);
+
+                console.log(`sliderGroup[${i}]:`);
+                console.log(sliderGroup[i]);
+
+                this.rect[0] = pxsim.svg.child(sliderGroup[i], "rect", {
+                    "width": this.getSliderWidth(),
+                    "height": this.getSliderHeight(),
+                    "style": `fill: url(#${gc})`
+                    }
+                );
+
+                console.log(`this.rect[${i}]:`);
+                console.log(this.rect[0]);
+            }
+            /*
+            const sliderGroupR = pxsim.svg.child(this.group, "g");
+            const sliderGroupG = pxsim.svg.child(this.group, "g");
+            const sliderGroupB = pxsim.svg.child(this.group, "g");
+            sliderGroupR.setAttribute("transform", `translate(${this.getWidth() / 2 - this.getSliderWidth() / 2 - 36}, ${this.getReporterHeight()})`);
+            sliderGroupG.setAttribute("transform", `translate(${this.getWidth() / 2 - this.getSliderWidth() / 2}, ${this.getReporterHeight()})`);
+            sliderGroupB.setAttribute("transform", `translate(${this.getWidth() / 2 - this.getSliderWidth() / 2 + 36}, ${this.getReporterHeight()})`);
+            console.log("sliderGroupR:");
+            console.log(sliderGroupR);
+            console.log("sliderGroupG:");
+            console.log(sliderGroupG);
+            console.log("sliderGroupB:");
+            console.log(sliderGroupB);
+
+            this.rect[0] = pxsim.svg.child(sliderGroupR, "rect", {
+                    "width": this.getSliderWidth(),
+                    "height": this.getSliderHeight(),
+                    "style": `fill: url(#${gc})`
+                }
+            );
+            this.rect[1] = pxsim.svg.child(sliderGroupG, "rect", {
+                    "width": this.getSliderWidth(),
+                    "height": this.getSliderHeight(),
+                    "style": `fill: url(#${gc})`
+                }
+            );
+            this.rect[2] = pxsim.svg.child(sliderGroupB, "rect", {
+                    "width": this.getSliderWidth(),
+                    "height": this.getSliderHeight(),
+                    "style": `fill: url(#${gc})`
+                }
+            );
+            
+            console.log("this.rectR:");
+            console.log(this.rect[0]);
+            console.log("this.rectG:");
+            console.log(this.rect[1]);
+            console.log("this.rectB:");
+            console.log(this.rect[2]);
+            */
+
+            let pt = parent.createSVGPoint();
+            let captured: boolean[] = [false, false, false];
+
+            touchEvents(this.rect[0], ev => {
+                if (captured[0] && (ev as MouseEvent).clientY) {
+                    ev.preventDefault();
+                    this.updateColorLevel(pt, parent, ev as MouseEvent);
+                }
+            }, ev => {
+                captured[0] = true;
+                if ((ev as MouseEvent).clientY) {
+                    this.rect[0].setAttribute('cursor', '-webkit-grabbing');
+                    this.updateColorLevel(pt, parent, ev as MouseEvent);
+                }
+            }, () => {
+                captured[0] = false;
+                this.rect[0].setAttribute('cursor', '-webkit-grab');
+            });
+
+            return this.group;
+        }
+    }
+}

--- a/sim/visuals/controls/colorRGBWheel.ts
+++ b/sim/visuals/controls/colorRGBWheel.ts
@@ -5,7 +5,6 @@ namespace pxsim.visuals {
         private colorGradient: SVGLinearGradientElement[] = [];
         private reporter: SVGTextElement[] = [];
         private rect: SVGElement[] = [];
-
         private printOffsetH = 16;
         private rgbLetters: string[] = ["R", "G", "B"];
         private rectNames: string[] = ["rectR", "rectG", "rectB"];
@@ -33,7 +32,7 @@ namespace pxsim.visuals {
         }
 
         private getMaxValue() {
-            return 511;
+            return 512;
         }
 
         private mapValue(x: number, inMin: number, inMax: number, outMin: number, outMax: number) {
@@ -44,8 +43,6 @@ namespace pxsim.visuals {
             if (!this.visible) return;
             const node = this.state;
             const values = node.getValues();
-            //console.log("values: ");
-            //console.log(values);
             let inverseValue: number[] = [];
             for (let i = 0; i < 3; i++) {
                 inverseValue[i] = this.getMaxValue() - values[i];
@@ -56,13 +53,9 @@ namespace pxsim.visuals {
         }
 
         updateColorLevel(pt: SVGPoint, parent: SVGSVGElement, ev: MouseEvent) {
-            //console.log(ev);
-            //console.log(ev.target);
             if (!this.classVal) this.classVal = (ev.target as HTMLElement).classList.value;
-            //console.log("classVal: " + this.classVal);
             let cur = svg.cursorPoint(pt, parent, ev);
             let index = this.rectNames.findIndex(i => i == this.classVal);
-            //console.log("index: " + index);
             const bBox = this.rect[index].getBoundingClientRect();
             const height = bBox.height;
             let t = Math.max(0, Math.min(1, (height + bBox.top / this.scaleFactor - cur.y / this.scaleFactor) / height));
@@ -84,18 +77,12 @@ namespace pxsim.visuals {
                 svg.setGradientColors(this.colorGradient[i], "black", "yellow");
             }
 
-            let pt = parent.createSVGPoint();
-
             let reporterGroup: SVGElement[] = [];
             for (let i = 0; i < 3; i++) {
                 reporterGroup[i] = pxsim.svg.child(this.group, "g");
-                //console.log(`reporterGroup[${i}]:`);
-                //console.log(reporterGroup[i]);
 
                 reporterGroup[i].setAttribute("transform", `translate(${this.getWidth() / 2}, ${18 + this.printOffsetH * i})`);
                 this.reporter[i] = pxsim.svg.child(reporterGroup[i], "text", { 'text-anchor': 'middle', 'class': 'sim-text number large inverted', 'style': 'font-size: 18px;' }) as SVGTextElement;
-                //console.log(`this.reporter[${i}]:`);
-                //console.log(this.reporter[0]);
             }
             
             let sliderGroup: SVGElement[] = [];
@@ -103,8 +90,6 @@ namespace pxsim.visuals {
                 sliderGroup[i] = pxsim.svg.child(this.group, "g");
                 const translateX = (this.getWidth() / 2 - this.getSliderWidth() / 2 - 36) + 36 * i;
                 sliderGroup[i].setAttribute("transform", `translate(${translateX}, ${this.getReporterHeight()})`);
-                //console.log(`sliderGroup[${i}]:`);
-                //console.log(sliderGroup[i]);
 
                 this.rect[i] = pxsim.svg.child(sliderGroup[i], "rect", {
                     "width": this.getSliderWidth(),
@@ -112,10 +97,9 @@ namespace pxsim.visuals {
                     "style": `fill: url(#${gc + "-" + i})`
                     }
                 );
-                //console.log(`this.rect[${i}]:`);
-                //console.log(this.rect[i]);
             }
 
+            let pt = parent.createSVGPoint();
             for (let i = 0; i < 3; i++) {
                 touchEvents(this.rect[i], ev => {
                     if (this.captured && (ev as MouseEvent).clientY) {

--- a/sim/visuals/controls/colorRGBWheel.ts
+++ b/sim/visuals/controls/colorRGBWheel.ts
@@ -66,6 +66,9 @@ namespace pxsim.visuals {
             svg.setGradientValue(this.colorGradient, "50%");
             svg.setGradientColors(this.colorGradient, "black", "yellow");
 
+            let pt = parent.createSVGPoint();
+            let captured: boolean[] = [false, false, false];
+
             let reporterGroup: SVGElement[] = [];
             for (let i = 0; i < 3; i++) {
                 reporterGroup[i] = pxsim.svg.child(this.group, "g");
@@ -89,7 +92,7 @@ namespace pxsim.visuals {
                 console.log(`sliderGroup[${i}]:`);
                 console.log(sliderGroup[i]);
 
-                this.rect[0] = pxsim.svg.child(sliderGroup[i], "rect", {
+                this.rect[i] = pxsim.svg.child(sliderGroup[i], "rect", {
                     "width": this.getSliderWidth(),
                     "height": this.getSliderHeight(),
                     "style": `fill: url(#${gc})`
@@ -97,67 +100,26 @@ namespace pxsim.visuals {
                 );
 
                 console.log(`this.rect[${i}]:`);
-                console.log(this.rect[0]);
+                console.log(this.rect[i]);
             }
-            /*
-            const sliderGroupR = pxsim.svg.child(this.group, "g");
-            const sliderGroupG = pxsim.svg.child(this.group, "g");
-            const sliderGroupB = pxsim.svg.child(this.group, "g");
-            sliderGroupR.setAttribute("transform", `translate(${this.getWidth() / 2 - this.getSliderWidth() / 2 - 36}, ${this.getReporterHeight()})`);
-            sliderGroupG.setAttribute("transform", `translate(${this.getWidth() / 2 - this.getSliderWidth() / 2}, ${this.getReporterHeight()})`);
-            sliderGroupB.setAttribute("transform", `translate(${this.getWidth() / 2 - this.getSliderWidth() / 2 + 36}, ${this.getReporterHeight()})`);
-            console.log("sliderGroupR:");
-            console.log(sliderGroupR);
-            console.log("sliderGroupG:");
-            console.log(sliderGroupG);
-            console.log("sliderGroupB:");
-            console.log(sliderGroupB);
 
-            this.rect[0] = pxsim.svg.child(sliderGroupR, "rect", {
-                    "width": this.getSliderWidth(),
-                    "height": this.getSliderHeight(),
-                    "style": `fill: url(#${gc})`
-                }
-            );
-            this.rect[1] = pxsim.svg.child(sliderGroupG, "rect", {
-                    "width": this.getSliderWidth(),
-                    "height": this.getSliderHeight(),
-                    "style": `fill: url(#${gc})`
-                }
-            );
-            this.rect[2] = pxsim.svg.child(sliderGroupB, "rect", {
-                    "width": this.getSliderWidth(),
-                    "height": this.getSliderHeight(),
-                    "style": `fill: url(#${gc})`
-                }
-            );
-            
-            console.log("this.rectR:");
-            console.log(this.rect[0]);
-            console.log("this.rectG:");
-            console.log(this.rect[1]);
-            console.log("this.rectB:");
-            console.log(this.rect[2]);
-            */
-
-            let pt = parent.createSVGPoint();
-            let captured: boolean[] = [false, false, false];
-
-            touchEvents(this.rect[0], ev => {
-                if (captured[0] && (ev as MouseEvent).clientY) {
-                    ev.preventDefault();
-                    this.updateColorLevel(pt, parent, ev as MouseEvent);
-                }
-            }, ev => {
-                captured[0] = true;
-                if ((ev as MouseEvent).clientY) {
-                    this.rect[0].setAttribute('cursor', '-webkit-grabbing');
-                    this.updateColorLevel(pt, parent, ev as MouseEvent);
-                }
-            }, () => {
-                captured[0] = false;
-                this.rect[0].setAttribute('cursor', '-webkit-grab');
-            });
+            for (let i = 0; i < 3; i++) {
+                touchEvents(this.rect[i], ev => {
+                    if (captured[i] && (ev as MouseEvent).clientY) {
+                        ev.preventDefault();
+                        this.updateColorLevel(pt, parent, ev as MouseEvent);
+                    }
+                }, ev => {
+                    captured[i] = true;
+                    if ((ev as MouseEvent).clientY) {
+                        this.rect[i].setAttribute('cursor', '-webkit-grabbing');
+                        this.updateColorLevel(pt, parent, ev as MouseEvent);
+                    }
+                }, () => {
+                    captured[i] = false;
+                    this.rect[i].setAttribute('cursor', '-webkit-grab');
+                });
+            }
 
             return this.group;
         }

--- a/sim/visuals/controls/colorWheel.ts
+++ b/sim/visuals/controls/colorWheel.ts
@@ -74,8 +74,6 @@ namespace pxsim.visuals {
 
             const rect = pxsim.svg.child(sliderGroup, "rect",
                 {
-                    "x": 0,
-                    "y": 0,
                     "width": this.getSliderWidth(),
                     "height": this.getSliderHeight(),
                     "style": `fill: url(#${gc})`

--- a/sim/visuals/nodes/colorSensorView.ts
+++ b/sim/visuals/nodes/colorSensorView.ts
@@ -28,6 +28,7 @@ namespace pxsim.visuals {
 
             switch (mode) {
                 case ColorSensorMode.Colors: this.updateSensorLightVisual('#0062DD'); return; // blue
+                case ColorSensorMode.RgbRaw: this.updateSensorLightVisual('#0062DD'); return; // blue
                 case ColorSensorMode.Reflected: this.updateSensorLightVisual('#F86262'); return; // red
                 case ColorSensorMode.RefRaw: this.updateSensorLightVisual('#F86262'); return; // red
                 case ColorSensorMode.Ambient: this.updateSensorLightVisual('#67C3E2'); return; // light blue


### PR DESCRIPTION
Added simulator support for RGB raw color sensor mode. To do this, I had to change the input code from the sensors and the color sensor code. Prior to this, there was no support for the fact that you can get an array of values.

![2023-05-13_23-00-02](https://github.com/microsoft/pxt-ev3/assets/13646226/371bc39e-71f3-479b-a9ec-c3d57f8c7f30)
