### PR TITLE
Changes in mode change for color sensor

### DIFF
--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -75,17 +75,15 @@ namespace sensors {
         setMode(m: ColorSensorMode) {
             // don't change threshold after initialization
             if (m != this.mode && this.isActive()) { // If the new mode is different from what was set for the sensor
-                /*
                 let maxModeRange = 0;
                 if (m == ColorSensorMode.RefRaw || m == ColorSensorMode.RgbRaw) maxModeRange = 1023;
                 else if (m == ColorSensorMode.Color) maxModeRange = 7;
                 else maxModeRange = 100; // ReflectedLightIntensity or AmbientLightIntensity
-                */
                 //const previousValue = this.mode == ColorSensorMode.RgbRaw ? this._queryArr()[0] : this._query(); // Before changing the mode, remember what the value was
                 this._setMode(m); // Change mode
                 //const startModeChangeTime = control.millis();
                 pause(MODE_SWITCH_DELAY);
-                pauseUntil(() => (this.getStatus() == 8 && (this.mode == ColorSensorMode.RgbRaw ? this._queryArr()[0] : this._query()) <= 1023)); // Pause until mode change
+                pauseUntil(() => (this.getStatus() == 8 && (this.mode == ColorSensorMode.RgbRaw ? this._queryArr()[0] : this._query()) <= maxModeRange)); // Pause until mode change
                 /*
                 const modeChangeTime = control.millis() - startModeChangeTime;
                 control.dmesg(`Previous value ${previousValue} before mode change on port ${this._port}`);

--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -75,13 +75,19 @@ namespace sensors {
         setMode(m: ColorSensorMode) {
             // don't change threshold after initialization
             if (m != this.mode && this.isActive()) { // If the new mode is different from what was set for the sensor
+                /*
+                let maxModeRange = 0;
+                if (m == ColorSensorMode.RefRaw || m == ColorSensorMode.RgbRaw) maxModeRange = 1023;
+                else if (m == ColorSensorMode.Color) maxModeRange = 7;
+                else maxModeRange = 100; // ReflectedLightIntensity or AmbientLightIntensity
+                */
                 //const previousValue = this.mode == ColorSensorMode.RgbRaw ? this._queryArr()[0] : this._query(); // Before changing the mode, remember what the value was
                 this._setMode(m); // Change mode
-                //const startChangeTime = control.millis();
+                //const startModeChangeTime = control.millis();
                 pause(MODE_SWITCH_DELAY);
-                pauseUntil(() => (this.getStatus() == 8 && (this.mode == ColorSensorMode.RgbRaw ? this._queryArr()[0] : this._query()) < 1024)); // Pause until mode change
+                pauseUntil(() => (this.getStatus() == 8 && (this.mode == ColorSensorMode.RgbRaw ? this._queryArr()[0] : this._query()) <= 1023)); // Pause until mode change
                 /*
-                const modeChangeTime = control.millis() - startChangeTime;
+                const modeChangeTime = control.millis() - startModeChangeTime;
                 control.dmesg(`Previous value ${previousValue} before mode change on port ${this._port}`);
                 control.dmesg(`Value ${this.mode == ColorSensorMode.RgbRaw ? this._queryArr()[0] : this._query()} after mode change in port ${this._port}`);
                 control.dmesg(`Time at mode change ${modeChangeTime} msec in port ${this._port}`);

--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -93,7 +93,7 @@ namespace sensors {
                         const currentValue = this._query();
                         if (previousValues[0] != currentValue && currentValue <= (m == ColorSensorMode.RefRaw ? 1023 : 100)) valueChangesCount++;
                     }
-                    pause(5);
+                    pause(valueChangesCount < 1 ? 5 : 10);
                 }
             } else {
                 // don't change threshold after initialization

--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -7,7 +7,7 @@ const enum ColorSensorMode {
     Color = 2,
     RefRaw = 3,
     RgbRaw = 4,
-    Calibration = 5,
+    ColorCal = 5,
 }
 
 enum LightIntensityMode {

--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -70,14 +70,17 @@ namespace sensors {
             return DAL.DEVICE_TYPE_COLOR
         }
 
-        setMode(m: ColorSensorMode) {
-            if (this.mode != m) { // If the new mode is different from what was set for the sensor
-                let previousValues: number[];
-                if (this.mode == ColorSensorMode.RgbRaw) previousValues = this._queryArr();
+        setMode(m: ColorSensorMode) {;
+            if (m != this.mode && this.isActive()) { // If the new mode is different from what was set for the sensor
+                let previousValues: number[] = [];
+                if (this.mode == ColorSensorMode.RgbRaw) previousValues = this._queryArr(); // Before changing the mode, remember what the value was
                 else previousValues[0] = this._query();
-                this._setMode(m);
-                let valueChangesCount = 0; // Value changes counter
-                while (valueChangesCount < 3) {
+                this._setMode(m); // Change mode
+                let valueChangesCount = 0; // Value change count
+                let currTime = 0;
+                const maxTime = control.millis() + 100;
+                while (valueChangesCount < 2 && currTime < maxTime) { // Waiting for multiple changes
+                    currTime = control.millis();
                     if (this.mode == ColorSensorMode.RgbRaw) { // Return array RGB mode
                         const currentValues = this._queryArr();
                         for (let i = 0; i < currentValues.length; i++) { // If any of the RGB components have changed
@@ -110,7 +113,7 @@ namespace sensors {
                 || this.mode == ColorSensorMode.AmbientLightIntensity
                 || this.mode == ColorSensorMode.ReflectedLightIntensity)
                 return this.getNumber(NumberFormat.UInt8LE, 0)
-            if (this.mode == ColorSensorMode.RefRaw)
+            else if (this.mode == ColorSensorMode.RefRaw)
                 return this.getNumber(NumberFormat.UInt16LE, 0)
             return 0
         }

--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -77,7 +77,7 @@ namespace sensors {
             if (m != this.mode && this.isActive()) { // If the new mode is different from what was set for the sensor
                 //const previousValue = this.mode == ColorSensorMode.RgbRaw ? this._queryArr()[0] : this._query(); // Before changing the mode, remember what the value was
                 this._setMode(m); // Change mode
-                const startChangeTime = control.millis();
+                //const startChangeTime = control.millis();
                 pause(MODE_SWITCH_DELAY);
                 pauseUntil(() => (this.getStatus() == 8 && (this.mode == ColorSensorMode.RgbRaw ? this._queryArr()[0] : this._query()) < 1024)); // Pause until mode change
                 /*

--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -81,6 +81,7 @@ namespace sensors {
                 const maxTime = control.millis() + 100;
                 while (valueChangesCount < 2 && currTime < maxTime) { // Waiting for multiple changes
                     currTime = control.millis();
+                    this.poke();
                     if (this.mode == ColorSensorMode.RgbRaw) { // Return array RGB mode
                         const currentValues = this._queryArr();
                         for (let i = 0; i < currentValues.length; i++) { // If any of the RGB components have changed
@@ -219,9 +220,9 @@ namespace sensors {
         //% group="Color Sensor"
         //% blockGap=8
         color(): ColorSensorColor {
+            this.setMode(ColorSensorMode.Color);
             this.poke();
-            this.setMode(ColorSensorMode.Color)
-            return this.getNumber(NumberFormat.UInt8LE, 0)
+            return this.getNumber(NumberFormat.UInt8LE, 0);
         }
 
         /**
@@ -253,8 +254,8 @@ namespace sensors {
         //% group="Color Sensor"
         //% blockGap=8
         rgbRaw(): number[] {
-            this.poke();
             this.setMode(ColorSensorMode.RgbRaw);
+            this.poke();
             return [this.getNumber(NumberFormat.UInt16LE, 0), this.getNumber(NumberFormat.UInt16LE, 2), this.getNumber(NumberFormat.UInt16LE, 4)];
         }
 
@@ -307,8 +308,8 @@ namespace sensors {
         //% weight=87 blockGap=8
         //% group="Color Sensor"
         light(mode: LightIntensityMode) {
-            this.poke();
             this.setMode(<ColorSensorMode><number>mode);
+            this.poke();
             switch (mode) {
                 case LightIntensityMode.ReflectedRaw:
                     return this.getNumber(NumberFormat.UInt16LE, 0);

--- a/libs/core/input.ts
+++ b/libs/core/input.ts
@@ -442,6 +442,10 @@ void      cUiUpdatePower(void)
             this._setMode(this.mode)
         }
 
+        getStatus() {
+            return getUartStatus(this._port);
+        }
+
         protected _setMode(m: number) {
             //control.dmesg(`_setMode p=${this.port} m: ${this.realmode} -> ${m}`)
             let v = m | 0


### PR DESCRIPTION
When changing the mode to Reflection Raw, I noticed that you can get inadequate ones. These numbers are greater than 1023, which cannot be at all. Something like 40 thousand.
I even recorded a video with this problem.
https://photos.app.goo.gl/ZKhqqND3uNrmJhPs5

I decided to write an algorithm inside the function for setting the operating mode. Valid only when the mode is changed once.
At first I just made the algorithm so that it simply ignored values greater than 1023, but then I remembered about other modes (reflection and external environment from 0 to 100, and color mode from 0 to 7). But later I realized that ignoring values greater than 1023 is not enough, because. we can get the values from the previous mode from the color sensor, this is from 0 to 100 (since at startup, the default mode is 0 - reflection mode).
I wrote a more complex algorithm that, when launched, initially looks at what the value was before switching the mode. Then in the loop it is checked that the value is not the same as before the mode change. For the cycle, a time protection of 100 ms is additionally implemented. During this time, the color sensor should definitely have changed several values.

In general, from experience, this was a problem for the implementation of movement along the line. In the loop before the algorithm, it was necessary to implement code with protection that the values in the mode of raw reflection values are less than 1024, because the algorithm for normalizing raw values in the range from 0 to 100 could give 0 immediately because of this, and the robot did not go anywhere right away, because. I thought he had already reached the crossroads.

The algorithm actually gives a bit of a delay of tens of ms before using the sensor, but so far I have not observed problems with the ralized code on hardware.
Lego in the firmware has something to poll whether the sensor has completed the mode change and whether it is ready to give data, but I did not understand how to implement this in Makecode.

![image](https://github.com/microsoft/pxt-ev3/assets/13646226/59f2907a-7b04-4182-8af7-2ae3750597d6)

I've seen some guys at competitions switch very quickly between color mode and reflection mode instantly while the robot is driving down the line. Of course, my code will not allow this, because there will be some delay. To do this, you need to implement a firmware poll about whether the sensor is ready to receive new values, which I showed above...