### PR TITLE
Sim scrollbar jump fix

### DIFF
--- a/theme/style.less
+++ b/theme/style.less
@@ -199,3 +199,9 @@
     background-color: #007EF4 !important;
     color: white !important;
 }
+
+/* Temporary fix simPanel jump for some screen resolutions so-as the problem is in the pxt version */
+.invisibleScrollbar::-webkit-scrollbar {
+    background: transparent !important;
+    width: initial !important;
+}

--- a/theme/style.less
+++ b/theme/style.less
@@ -200,7 +200,7 @@
     color: white !important;
 }
 
-/* Temporary fix simPanel jump for some screen resolutions so-as the problem is in the pxt version */
+/* Temporary fix simPanel jump for some screen resolutions so-as the problem is in the pxt version. Need pxt version 8.2.7 and up */
 .invisibleScrollbar::-webkit-scrollbar {
     background: transparent !important;
     width: initial !important;


### PR DESCRIPTION
At certain screen resolutions, jumps occur in the simulator.
This created an annoyance when the simulator jumped due to the vertical scroll bar appearing and disappearing.
Temporary solution before ptx-core is upgraded to at least v8.2.7.

https://github.com/microsoft/pxt/commit/84e896cbcadf8a78479a0867f5bc6dd53d0458a8