### PR TITLE
Motor speed invertedFactor usage

### DIFF
--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -19,12 +19,6 @@ enum Output {
     ALL = 0x0f
 }
 
-enum OutputType {
-    None = 0,
-    Tacho = 7,
-    MiniTacho = 8,
-}
-
 enum MoveUnit {
     //% block="rotations"
     Rotations,

--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -19,6 +19,12 @@ enum Output {
     ALL = 0x0f
 }
 
+enum OutputType {
+    None = 0,
+    Tacho = 7,
+    MiniTacho = 8,
+}
+
 enum MoveUnit {
     //% block="rotations"
     Rotations,

--- a/libs/core/output.ts
+++ b/libs/core/output.ts
@@ -592,7 +592,7 @@ namespace motors {
         //% help=motors/motor/speed
         speed(): number {
             this.init();
-            return getMotorData(this._port).actualSpeed;
+            return getMotorData(this._port).actualSpeed * this.invertedFactor();
         }
 
         /**


### PR DESCRIPTION
Added use of the invertedFactor() method in the speed() method. Done in the same way as for the case of the angle() method.

Before change
![Screenshot_3](https://github.com/microsoft/pxt-ev3/assets/13646226/6eca90ce-c6ef-40ec-8f92-aa395c4e17ac)

After the change
![Screenshot_4](https://github.com/microsoft/pxt-ev3/assets/13646226/f6c2382a-1e57-4d00-b3c4-ae060fda2bcf)

But the simulator itself still uses getMotorData(), which does not take into account motor inversion. Therefore, the value of the speed or angle with a minus is displayed there. I could not add invertedFactor() to getMotorData() for a specific motor, because the simulator immediately starts displaying motors that are not used in the program.

Changes like this...
https://github.com/microsoft/pxt-ev3/pull/999