### PR TITLE
Editor display changes

### DIFF
--- a/theme/style.less
+++ b/theme/style.less
@@ -119,10 +119,6 @@
     background: @simulatorBackground data-uri("../docs/static/backgrounds/simulator.png") 0 0 repeat !important;
 }
 
-#editortools {
-    overflow: hidden;
-}
-
 #downloadArea {
     background: @legoGreyLight;
 }

--- a/theme/style.less
+++ b/theme/style.less
@@ -119,10 +119,6 @@
     background: @simulatorBackground data-uri("../docs/static/backgrounds/simulator.png") 0 0 repeat !important;
 }
 
-#downloadArea {
-    background: @legoGreyLight;
-}
-
 /* Editor download dialog */
 .ui.downloaddialog.modal>.content {
     padding: 1rem;

--- a/theme/style.less
+++ b/theme/style.less
@@ -115,8 +115,12 @@
     text-transform: lowercase;
 }
 
-#filelist {
+#simulator .editor-sidebar {
     background: @simulatorBackground data-uri("../docs/static/backgrounds/simulator.png") 0 0 repeat !important;
+}
+
+#editortools {
+    overflow: hidden;
 }
 
 #downloadArea {


### PR DESCRIPTION
The first change returns the background pattern as in the stable version.

The second change is to fix #downloadArea overlapping on the simulator. I don’t really understand why this bug is visible only in pxt-ev3. This bug is not detected in microbit, but the #downloadArea field is also larger than the height of #editortools itself. I compared the properties, but they seem to be all the same.

It was and became
![image](https://github.com/microsoft/pxt-ev3/assets/13646226/1c755a2a-d0fd-4848-981c-d6b9afa2febd)
![image](https://github.com/microsoft/pxt-ev3/assets/13646226/ea71d859-bd81-4b05-a441-7ceeff6f98d5)
