### PR TITLE
Screen clear lines block

### DIFF
--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -315,7 +315,7 @@ namespace brick {
      * Clear on the screen at a specific lines.
      * @param lines list of lines to clear (starting at 1 and ends with 12)
      */
-    //% blockId=clearLines block="clear line(s) $lines"
+    //% blockId=clearLines block="clear lines $lines"
     //% weight=94 group="Screen" inlineInputMode="inline" blockGap=8
     export function clearLines(lines: number[]) {
         if (screenMode != ScreenMode.ShowLines) {
@@ -324,7 +324,7 @@ namespace brick {
         }
 
         for (let i = 0; i < lines.length; i++) {
-            clearLine(i);
+            clearLine(lines[i]);
         }
     }
 

--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -312,12 +312,30 @@ namespace brick {
     }
 
     /**
+     * Clear on the screen at a specific line or lines.
+     * @param lines list of lines to clear (starting at 1)
+     */
+    //% blockId=clearLines block="clear line(s) $lines"
+    //% weight=94 group="Screen" inlineInputMode="inline" blockGap=8
+    export function clearLines(lines: number[]) {
+        if (screenMode != ScreenMode.ShowLines) {
+            screenMode = ScreenMode.ShowLines;
+            screen.fill(0);
+        }
+
+        for (let i = 0; i < lines.length; i++) {
+            clearLine(i);
+        }
+    }
+
+    /**
      * Clear on the screen at a specific line.
      * @param line the line number to clear at (starting at 1), eg: 1
      */
     //% blockId=clearLine block="clear line $line"
-    //% weight=94 group="Screen" inlineInputMode="inline" blockGap=8
+    //% weight=93 group="Screen" inlineInputMode="inline" blockGap=8
     //% line.min=1 line.max=12
+    //% deprecated=true
     export function clearLine(line: number) {
         if (screenMode != ScreenMode.ShowLines) {
             screenMode = ScreenMode.ShowLines;
@@ -337,7 +355,7 @@ namespace brick {
      * Clear the screen
      */
     //% blockId=screen_clear_screen block="clear screen"
-    //% weight=93 group="Screen"
+    //% weight=92 group="Screen"
     //% help=brick/clear-screen weight=1
     export function clearScreen() {
         screen.fill(0)

--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -312,7 +312,7 @@ namespace brick {
     }
 
     /**
-     * Clear on the screen at a specific lines.
+     * Clear on the screen at a specific lines (1..12).
      * @param lines list of lines to clear (starting at 1 and ends with 12)
      */
     //% blockId=clearLines block="clear lines $lines"

--- a/libs/screen/targetoverrides.ts
+++ b/libs/screen/targetoverrides.ts
@@ -312,8 +312,8 @@ namespace brick {
     }
 
     /**
-     * Clear on the screen at a specific line or lines.
-     * @param lines list of lines to clear (starting at 1)
+     * Clear on the screen at a specific lines.
+     * @param lines list of lines to clear (starting at 1 and ends with 12)
      */
     //% blockId=clearLines block="clear line(s) $lines"
     //% weight=94 group="Screen" inlineInputMode="inline" blockGap=8
@@ -335,7 +335,6 @@ namespace brick {
     //% blockId=clearLine block="clear line $line"
     //% weight=93 group="Screen" inlineInputMode="inline" blockGap=8
     //% line.min=1 line.max=12
-    //% deprecated=true
     export function clearLine(line: number) {
         if (screenMode != ScreenMode.ShowLines) {
             screenMode = ScreenMode.ShowLines;


### PR DESCRIPTION
A block that can clear multiple lines at once. In general, it is necessary so that in the screen output cycle, first clearing, and then printing ten lines, flickering occurs on the screen because screen output is not a fast operation. Therefore, I think that it is better to clear some lines first before outputting to them.

![image](https://github.com/microsoft/pxt-ev3/assets/13646226/b085496f-c287-4a52-a981-44d1bfcc1c1f)

I would indicate the default values of the array, but as I understand it, pxt-core does not support such an option.