### PR TITLE
Bump pxt-core and some other changes and fixes

### DIFF
--- a/libs/color-sensor/color.ts
+++ b/libs/color-sensor/color.ts
@@ -120,7 +120,7 @@ namespace sensors {
                         "brown"][this._query()[0]]];
                 case ColorSensorMode.AmbientLightIntensity:
                 case ColorSensorMode.ReflectedLightIntensity:
-                    return [`${this._query()}%`];
+                    return [`${this._query()[0]}%`];
                 case ColorSensorMode.RgbRaw:
                     return this._query().map(number => number.toString());
                 default:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "pxt-common-packages": "11.1.2",
-    "pxt-core": "9.1.23"
+    "pxt-core": "9.3.5"
   },
   "scripts": {
     "test": "node node_modules/pxt-core/built/pxt.js travis"


### PR DESCRIPTION
I upgraded the pxt-core version because... there was a big version jump.
Fixed a bug that previously allowed object to be displayed on the screen for the ambient and reflected color sensor modes.
Also some small changes will be added here.