### PR TITLE
Fixed set mode of raw reflection values (mode numbered zero) in simulator for nxt light sensor

### DIFF
--- a/libs/core/input.ts
+++ b/libs/core/input.ts
@@ -256,6 +256,7 @@ namespace sensors.internal {
             } else if (newConn == DAL.CONN_NXT_DUMB) {
                 sensorInfo.devType = inDcm[sensorInfo.port];
                 control.dmesg(`new NXT DUMB connection at port ${sensorInfo.port} dev type ${sensorInfo.devType}`);
+                setAnalogMode(sensorInfo.port, sensorInfo.devType, 0);
             } else if (newConn == DAL.CONN_INPUT_DUMB) {
                 //sensorInfo.devType = inDcm[sensorInfo.port]; // We get the result DEVICE_TYPE_UNKNOWN
                 sensorInfo.devType = DAL.DEVICE_TYPE_TOUCH; // TODO? for now assume touch
@@ -367,7 +368,6 @@ namespace sensors.internal {
         }
 
         _activated() {
-            this.realmode = 0;
             this._setMode(this.mode);
         }
 
@@ -417,7 +417,6 @@ namespace sensors.internal {
         }
 
         protected _setMode(m: number) {
-            //control.dmesg(`_setMode p=${this.port} m: ${this.realmode} -> ${m}`);
             let v = m | 0;
             this.mode = v;
             if (!this.isActive()) return;


### PR DESCRIPTION
The _setMode() method was called, and just like at the beginning of this.mode = 0, this.realmode = 0, the algorithm in _setMode checks this.realmode != this.mode and only then calls setAnalogMode(), in which the mode is passed to the simulator.

When we find the DAL.CONN_NXT_DUMB sensor in detectDevices(), we additionally call setAnalogMode(). Perhaps the same thing needs to be done for DAL.CONN_INPUT_DUMB, but there is only one analog sensor ev3 (touch sensor), and it works without this change. This way you set the mode forcibly when the sensor is found, i.e. at the beginning.

I did the same thing as when finding DAL.CONN_INPUT_UART, in that case updateUartMode() is called.