### PR TITLE
Fix broken categories in pxtToolbox

### DIFF
--- a/libs/core/ns.ts
+++ b/libs/core/ns.ts
@@ -1,4 +1,6 @@
-
+//% color="#00852B" weight=90 icon="\uf10d"
+//% groups='["Move", "Counters", "Properties"]'
+//% labelLineWidth=50
 namespace motors {
 
     /**
@@ -24,7 +26,13 @@ namespace motors {
     }
 }
 
-//% icon="\uf112"
-namespace console {
+//% color="#C8509B" weight=95 icon="\uf10f"
+//% labelLineWidth=100
+//% groups='["Touch Sensor", "Color Sensor", "Ultrasonic Sensor", "Gyro Sensor", "Infrared Sensor", "Remote Infrared Beacon",  "Light Sensor"]'
+//% subcategories='["NXT", "HiTechnic"]'
+namespace sensors {
+}
 
+//% color="#5F3109" icon="\uf107"
+namespace control {
 }

--- a/libs/core/ns.ts
+++ b/libs/core/ns.ts
@@ -36,3 +36,9 @@ namespace sensors {
 //% color="#5F3109" icon="\uf107"
 namespace control {
 }
+
+//% color="#68C3E2" weight=100 icon="\uf106"
+//% groups='["Buttons", "Indicator", "Screen", "Power", "Program"]'
+//% labelLineWidth=60
+namespace brick {
+}

--- a/libs/ev3/ns.ts
+++ b/libs/ev3/ns.ts
@@ -1,9 +1,3 @@
-//% color="#68C3E2" weight=100 icon="\uf106"
-//% groups='["Buttons", "Indicator", "Screen", "Power", "Program"]'
-//% labelLineWidth=60
-namespace brick {
-}
-
 //% icon="\uf112"
 namespace console {
 }

--- a/libs/ev3/ns.ts
+++ b/libs/ev3/ns.ts
@@ -4,31 +4,13 @@
 namespace brick {
 }
 
-//% color="#C8509B" weight=95 icon="\uf10f"
-//% labelLineWidth=100
-//% groups='["Touch Sensor", "Color Sensor", "Ultrasonic Sensor", "Gyro Sensor", "Infrared Sensor", "Remote Infrared Beacon",  "Light Sensor"]'
-//% subcategories='["NXT", "HiTechnic"]'
-namespace sensors {
-}
-
-//% color="#00852B" weight=90 icon="\uf10d"
-//% groups='["Move", "Counters", "Properties"]'
-//% labelLineWidth=50
-namespace motors {
+//% icon="\uf112"
+namespace console {
 }
 
 //% color="#00852B" icon="\uf1b9" weight=85
 //% labelLineWidth=0
 namespace chassis {
-}
-
-//% color="#D67923" weight=80 icon="\uf10e"
-//% groups='["Sounds", "Tone", "Volume", "Tempo"]'
-namespace music {
-}
-
-//% color="#5F3109" icon="\uf107"
-namespace control {
 }
 
 //% icon="\uf0d0"

--- a/libs/ev3/pxt.json
+++ b/libs/ev3/pxt.json
@@ -2,8 +2,8 @@
     "name": "ev3",
     "description": "The EV3 library",
     "files": [
-        "README.md",        
-        "ns.ts",
+        "README.md", 
+        "ns.ts",       
         "brick.ts",
         "startup.ts",
         "images.jres",
@@ -27,8 +27,8 @@
         "infrared-sensor": "file:../infrared-sensor"
     },
     "palette": [
-       "#ffffff",
-       "#000000"
+        "#ffffff",
+        "#000000"
     ],
     "public": true
 }

--- a/libs/music/ns.ts
+++ b/libs/music/ns.ts
@@ -1,0 +1,4 @@
+//% color="#D67923" weight=80 icon="\uf10e"
+//% groups='["Sounds", "Tone", "Volume", "Tempo"]'
+namespace music {
+}


### PR DESCRIPTION
I created a fix for pxtToolbox which breaks when adding some extensions. This bug appeared during the first beta version. I have attached a video of how this happens.
I actually don't understand why this leads to such a bug and why my solution works.

But adding custom.ts solved the bug. I don't know why this happens either.

Another observation worth noting is that the extensions that come from github do not break the categories in pxtToolbox.

https://github.com/microsoft/pxt-ev3/assets/13646226/02be39cf-ff8f-42fc-ace5-6c39e9a53090