### PR TITLE
Field-motors fix

### DIFF
--- a/fieldeditors/field_motors.ts
+++ b/fieldeditors/field_motors.ts
@@ -108,6 +108,7 @@ export class FieldMotors extends pxtblockly.FieldImages implements Blockly.Field
         }
         contentDiv.style.width = (this as any).width_ + 'px';
         contentDiv.style.display = 'flex';
+        contentDiv.style.flexWrap = 'wrap';
         contentDiv.style.alignItems = 'stretch';
         dropdownDiv.appendChild(contentDiv);
 


### PR DESCRIPTION
I made a mistake, I apologize and add a quick fix. This is due to this change - https://github.com/microsoft/pxt-ev3/pull/1043/files
Menuitems, when they were displayed in large numbers, were not wrapped on new lines due to the flex-wrap: wrap not being added. This concerned run blocks.

![image](https://github.com/microsoft/pxt-ev3/assets/13646226/c07ff711-66ea-4cdf-9b80-e116b18e6d53)
![image](https://github.com/microsoft/pxt-ev3/assets/13646226/46f40406-4d2f-4c3b-8124-56f07d387133)
![image](https://github.com/microsoft/pxt-ev3/assets/13646226/c79ccf18-9099-4590-924c-be438488557c)
![image](https://github.com/microsoft/pxt-ev3/assets/13646226/f45266e3-3ab9-4126-bfec-61b7d3c939c4)
![image](https://github.com/microsoft/pxt-ev3/assets/13646226/5a080507-2a76-4b4c-a3d8-3cb91b860161)