### PR TITLE
Remove stale sections approveRepos and preferredRepos

### DIFF
--- a/targetconfig.json
+++ b/targetconfig.json
@@ -4,13 +4,6 @@
             "Microsoft",
             "LEGO"
         ],
-        "approvedRepos": [
-            "microsoft/pxt-automation",
-            "THEb0nny/makecode-ev3-hitechnic-color-sensor-v2"
-        ],
-        "preferredRepos": [
-            "microsoft/pxt-automation"
-        ],
         "approvedRepoLib": {
             "microsoft/pxt-automation": {
                 "preferred": true


### PR DESCRIPTION
We have new section approvedRepoLib which handles this.
https://github.com/microsoft/pxt-microbit/pull/5401

Everything seems to be fine, the extensions remain in place.