### PR TITLE
Tilt angle mode for gyro sensor

### DIFF
--- a/libs/gyro-sensor/gyro.ts
+++ b/libs/gyro-sensor/gyro.ts
@@ -84,6 +84,18 @@ namespace sensors {
             return Math.round(this._rotationAngle.value);
         }
 
+        /**
+         * Get the current rotate angle from the gyroscope.
+         * @param sensor the gyroscope to query the request
+         */
+        //% help=sensors/gyro/rotate-angle
+        //% block="**gyro** %this|rotate angle"
+        //% blockId=gyroGetRotateAngle
+        //% parts="gyroscope"
+        //% blockNamespace=sensors
+        //% this.fieldEditor="ports"
+        //% weight=100 blockGap=8
+        //% group="Gyro Sensor"
         rotationAngle(method: GyroGetMethodValues = GyroGetMethodValues.RateEulerIntegrator): number {
             if (method == GyroGetMethodValues.RateEulerIntegrator) return this.angle();
             else if (method == GyroGetMethodValues.DeflVersion) {
@@ -97,6 +109,18 @@ namespace sensors {
             return 0;
         }
 
+        /**
+         * Get the current tilt angle from the gyroscope.
+         * @param sensor the gyroscope to query the request
+         */
+        //% help=sensors/gyro/tilt-angle
+        //% block="**gyro** %this|tilt angle"
+        //% blockId=gyroGetTiltAngle
+        //% parts="gyroscope"
+        //% blockNamespace=sensors
+        //% this.fieldEditor="ports"
+        //% weight=99 blockGap=8
+        //% group="Gyro Sensor"
         tiltAngle(method: GyroGetMethodValues = GyroGetMethodValues.RateEulerIntegrator): number {
             if (method == GyroGetMethodValues.RateEulerIntegrator) {
                 this.setMode(GyroSensorMode.TiltRate);
@@ -138,10 +162,34 @@ namespace sensors {
             return this._query()[0] - this._rotationDrift;
         }
 
+        /**
+         * Get the current rotation rate from the gyroscope.
+         * @param sensor the gyroscope to query the request
+         */
+        //% help=sensors/gyro/rotation-rate
+        //% block="**gyro** %this|rotation rate"
+        //% blockId=gyroGetRotationRate
+        //% parts="gyroscope"
+        //% blockNamespace=sensors
+        //% this.fieldEditor="ports"
+        //% weight=99 blockGap=8
+        //% group="Gyro Sensor"
         rotationRate(): number {
             return this.rate();
         }
 
+        /**
+         * Get the current tilt rate from the gyroscope.
+         * @param sensor the gyroscope to query the request
+         */
+        //% help=sensors/gyro/tilt-rate
+        //% block="**gyro** %this|tilt rate"
+        //% blockId=gyroGetTiltRate
+        //% parts="gyroscope"
+        //% blockNamespace=sensors
+        //% this.fieldEditor="ports"
+        //% weight=98 blockGap=8
+        //% group="Gyro Sensor"
         tiltRate(): number {
             this.setMode(GyroSensorMode.TiltRate);
             this.poke();
@@ -175,8 +223,9 @@ namespace sensors {
             pause(700);
 
             // compute drift
-            this.computeDriftNoCalibration();
-            if (Math.abs(this.drift()) < 0.1) {
+            //this.computeTiltDriftNoCalibration();
+            this.computeRotationDriftNoCalibration();
+            if (Math.abs(this.rotationDrift()) < 0.1) {
                 // no drift, skipping calibration
                 brick.setStatusLight(StatusLight.Green); // success
                 pause(1000);
@@ -184,6 +233,7 @@ namespace sensors {
 
                 // and we're done
                 this._rotationAngle.reset();
+                this._tiltAngle.reset();
                 this._calibrating = false;
                 return;
             }
@@ -206,12 +256,13 @@ namespace sensors {
                 pause(2000);
                 brick.setStatusLight(statusLight); // restore previous light
                 this._rotationAngle.reset();
+                this._tiltAngle.reset();
                 this._calibrating = false;
                 return;
             }
 
-            // switch to rate mode
-            this.computeDriftNoCalibration();
+            //this.computeTiltDriftNoCalibration();
+            this.computeRotationDriftNoCalibration(); // switch to rate mode
 
             // and done
             brick.setStatusLight(StatusLight.Green); // success
@@ -220,6 +271,7 @@ namespace sensors {
 
             // and we're done
             this._rotationAngle.reset();
+            this._tiltAngle.reset();
             this._calibrating = false;
         }
 
@@ -244,7 +296,9 @@ namespace sensors {
             // send a reset command
             super.reset();
             this._rotationDrift = 0;
+            this._tiltDrift = 0;
             this._rotationAngle.reset();
+            this._tiltAngle.reset();
             pauseUntil(() => this.isActive(), 7000);
 
             // check sensor is ready
@@ -253,6 +307,7 @@ namespace sensors {
                 pause(2000);
                 brick.setStatusLight(statusLight); // restore previous light
                 this._rotationAngle.reset();
+                this._tiltAngle.reset();
                 this._calibrating = false;
                 return;
             }
@@ -265,6 +320,7 @@ namespace sensors {
             brick.setStatusLight(statusLight); // resture previous light
             // and done
             this._rotationAngle.reset();
+            this._tiltAngle.reset();
             this._calibrating = false;
         }
 
@@ -279,8 +335,39 @@ namespace sensors {
         //% this.fieldEditor="ports"
         //% weight=78 blockGap=8
         //% group="Gyro Sensor"
+        //% deprecated=true
         drift(): number {
             return this._rotationDrift;
+        }
+
+        /**
+         * Gets the computed rotation rate drift.
+         */
+        //% help=sensors/gyro/rotation-drift
+        //% block="**gyro** %this|rotation drift"
+        //% blockId=gyroRotationDrift
+        //% parts="gyroscope"
+        //% blockNamespace=sensors
+        //% this.fieldEditor="ports"
+        //% weight=78 blockGap=8
+        //% group="Gyro Sensor"
+        rotationDrift(): number {
+            return this._rotationDrift;
+        }
+
+        /**
+         * Gets the computed tilt rate drift.
+         */
+        //% help=sensors/gyro/tilt-drift
+        //% block="**gyro** %this|tilt drift"
+        //% blockId=gyroTiltDrift
+        //% parts="gyroscope"
+        //% blockNamespace=sensors
+        //% this.fieldEditor="ports"
+        //% weight=78 blockGap=8
+        //% group="Gyro Sensor"
+        tiltDrift(): number {
+            return this._tiltDrift;
         }
 
         /**
@@ -294,11 +381,48 @@ namespace sensors {
         //% this.fieldEditor="ports"
         //% weight=79 blockGap=8
         //% group="Gyro Sensor"
+        //% deprecated=true
         computeDrift() {
             if (this._calibrating)
                 pauseUntil(() => !this._calibrating, 2000);
             pause(1000); // let the robot settle
-            this.computeDriftNoCalibration();
+            this.computeRotationDriftNoCalibration();
+        }
+
+        /**
+         * Computes the current sensor rotation drift when using rate measurements.
+         */
+        //% help=sensors/gyro/compute-rotation-drift
+        //% block="compute **gyro** %this|rotation drift"
+        //% blockId=gyroComputeRotationDrift
+        //% parts="gyroscope"
+        //% blockNamespace=sensors
+        //% this.fieldEditor="ports"
+        //% weight=79 blockGap=8
+        //% group="Gyro Sensor"
+        computeRotationDrift() {
+            if (this._calibrating)
+                pauseUntil(() => !this._calibrating, 2000);
+            pause(1000); // let the robot settle
+            this.computeRotationDriftNoCalibration();
+        }
+
+        /**
+         * Computes the current sensor tilt drift when using rate measurements.
+         */
+        //% help=sensors/gyro/compute-tilt-drift
+        //% block="compute **gyro** %this|tilt drift"
+        //% blockId=gyroComputeTiltDrift
+        //% parts="gyroscope"
+        //% blockNamespace=sensors
+        //% this.fieldEditor="ports"
+        //% weight=79 blockGap=8
+        //% group="Gyro Sensor"
+        computeTiltDrift() {
+            if (this._calibrating)
+                pauseUntil(() => !this._calibrating, 2000);
+            pause(1000); // let the robot settle
+            this.computeTiltDriftNoCalibration();
         }
 
         /**
@@ -322,8 +446,8 @@ namespace sensors {
             pauseUntil(() => (end - this.angle()) * direction <= 0, timeOut);
         }
 
-        private computeDriftNoCalibration() {
-            // clear drift
+        private computeRotationDriftNoCalibration() {
+            // clear rotation drift
             this._rotationDrift = 0;
             const n = 10;
             let d = 0;
@@ -335,14 +459,38 @@ namespace sensors {
             this._rotationAngle.reset();
         }
 
-        _info() {
-            if (this._calibrating)
-                return ["cal..."];
+        private computeTiltDriftNoCalibration() {
+            // clear tilt drift
+            this._tiltDrift = 0;
+            const n = 10;
+            let d = 0;
+            for (let i = 0; i < n; ++i) {
+                d += this._query()[0];
+                pause(20);
+            }
+            this._tiltDrift = d / n;
+            this._tiltAngle.reset();
+        }
 
-            let r = `${this._query()[0]}r`;
-            if (this._rotationDrift != 0)
-                r += `-${this._rotationDrift | 0}`;
-            return [r];
+        _info() {
+            if (this._calibrating) {
+                return ["cal..."];
+            }
+
+            if (this.mode == GyroSensorMode.Rate || this.mode == GyroSensorMode.Angle) {
+                let r = `${this._query()[0]}r`;
+                if (this._rotationDrift != 0) {
+                    r += `-${this._rotationDrift | 0}`;
+                }
+                return [r];
+            } else if (this.mode == GyroSensorMode.TiltRate || this.mode == GyroSensorMode.TiltAngle) {
+                let r = `${this._query()[0]}r`;
+                if (this._tiltDrift != 0) {
+                    r += `-${this._tiltDrift | 0}`;
+                }
+                return [r];
+            }
+            return [`0`];
         }
     }
 

--- a/libs/gyro-sensor/gyro.ts
+++ b/libs/gyro-sensor/gyro.ts
@@ -9,9 +9,18 @@ const enum GyroSensorMode {
     TiltAngle = 6 // Tilt angle
 }
 
-const enum GyroGetMethodValues {
+const enum GyroGetAngleMethod {
+    //% block="rate Euler integrator"
     RateEulerIntegrator = 0,
-    DeflVersion = 1
+    //% block="default"
+    Default = 1
+}
+
+const enum GyroAxis {
+    //% block="rotation"
+    Rotation,
+    //% block="tilt"
+    Tilt
 }
 
 namespace sensors {
@@ -87,18 +96,20 @@ namespace sensors {
         /**
          * Get the current rotate angle from the gyroscope.
          * @param sensor the gyroscope to query the request
+         * @param method the method to get the value
          */
         //% help=sensors/gyro/rotate-angle
-        //% block="**gyro** %this|rotate angle"
+        //% block="**gyro** $this|rotation angle||at $method|metod"
         //% blockId=gyroGetRotateAngle
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
+        //% expandableArgumentMode="toggle"
         //% weight=100 blockGap=8
         //% group="Gyro Sensor"
-        rotationAngle(method: GyroGetMethodValues = GyroGetMethodValues.RateEulerIntegrator): number {
-            if (method == GyroGetMethodValues.RateEulerIntegrator) return this.angle();
-            else if (method == GyroGetMethodValues.DeflVersion) {
+        rotationAngle(method: GyroGetAngleMethod = GyroGetAngleMethod.RateEulerIntegrator): number {
+            if (method == GyroGetAngleMethod.RateEulerIntegrator) return this.angle();
+            else if (method == GyroGetAngleMethod.Default) {
                 this.setMode(GyroSensorMode.Angle);
                 this.poke();
                 if (this._calibrating) {
@@ -112,24 +123,26 @@ namespace sensors {
         /**
          * Get the current tilt angle from the gyroscope.
          * @param sensor the gyroscope to query the request
+         * @param method the method to get the value
          */
         //% help=sensors/gyro/tilt-angle
-        //% block="**gyro** %this|tilt angle"
+        //% block="**gyro** $this|tilt angle||at $method|metod"
         //% blockId=gyroGetTiltAngle
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
-        //% weight=99 blockGap=8
+        //% expandableArgumentMode="toggle"
+        //% weight=99
         //% group="Gyro Sensor"
-        tiltAngle(method: GyroGetMethodValues = GyroGetMethodValues.RateEulerIntegrator): number {
-            if (method == GyroGetMethodValues.RateEulerIntegrator) {
+        tiltAngle(method: GyroGetAngleMethod = GyroGetAngleMethod.RateEulerIntegrator): number {
+            if (method == GyroGetAngleMethod.RateEulerIntegrator) {
                 this.setMode(GyroSensorMode.TiltRate);
                 this.poke();
                 if (this._calibrating) {
                     pauseUntil(() => !this._calibrating, 2000);
                 }
                 return Math.round(this._tiltAngle.value);
-            } else if (method == GyroGetMethodValues.DeflVersion) {
+            } else if (method == GyroGetAngleMethod.Default) {
                 this.setMode(GyroSensorMode.TiltAngle);
                 this.poke();
                 if (this._calibrating) {
@@ -150,7 +163,7 @@ namespace sensors {
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
-        //% weight=99 blockGap=8
+        //% weight=98 blockGap=8
         //% group="Gyro Sensor"
         //% deprecated=true
         rate(): number {
@@ -167,12 +180,12 @@ namespace sensors {
          * @param sensor the gyroscope to query the request
          */
         //% help=sensors/gyro/rotation-rate
-        //% block="**gyro** %this|rotation rate"
+        //% block="**gyro** $this|rotation rate"
         //% blockId=gyroGetRotationRate
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
-        //% weight=99 blockGap=8
+        //% weight=98 blockGap=8
         //% group="Gyro Sensor"
         rotationRate(): number {
             return this.rate();
@@ -183,12 +196,12 @@ namespace sensors {
          * @param sensor the gyroscope to query the request
          */
         //% help=sensors/gyro/tilt-rate
-        //% block="**gyro** %this|tilt rate"
+        //% block="**gyro** $this|tilt rate"
         //% blockId=gyroGetTiltRate
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
-        //% weight=98 blockGap=8
+        //% weight=97
         //% group="Gyro Sensor"
         tiltRate(): number {
             this.setMode(GyroSensorMode.TiltRate);
@@ -209,7 +222,7 @@ namespace sensors {
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
-        //% weight=89 blockGap=8
+        //% weight=69 blockGap=8
         //% group="Gyro Sensor"
         calibrate(): void {
             if (this._calibrating) return; // already in calibration mode
@@ -284,7 +297,7 @@ namespace sensors {
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
-        //% weight=88
+        //% weight=68
         //% group="Gyro Sensor"
         reset(): void {
             if (this._calibrating) return; // already in calibration mode
@@ -333,7 +346,7 @@ namespace sensors {
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
-        //% weight=78 blockGap=8
+        //% weight=89 blockGap=8
         //% group="Gyro Sensor"
         //% deprecated=true
         drift(): number {
@@ -344,12 +357,12 @@ namespace sensors {
          * Gets the computed rotation rate drift.
          */
         //% help=sensors/gyro/rotation-drift
-        //% block="**gyro** %this|rotation drift"
+        //% block="**gyro** $this|rotation drift"
         //% blockId=gyroRotationDrift
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
-        //% weight=78 blockGap=8
+        //% weight=89 blockGap=8
         //% group="Gyro Sensor"
         rotationDrift(): number {
             return this._rotationDrift;
@@ -359,12 +372,12 @@ namespace sensors {
          * Gets the computed tilt rate drift.
          */
         //% help=sensors/gyro/tilt-drift
-        //% block="**gyro** %this|tilt drift"
+        //% block="**gyro** $this|tilt drift"
         //% blockId=gyroTiltDrift
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
-        //% weight=78 blockGap=8
+        //% weight=88
         //% group="Gyro Sensor"
         tiltDrift(): number {
             return this._tiltDrift;
@@ -393,7 +406,7 @@ namespace sensors {
          * Computes the current sensor rotation drift when using rate measurements.
          */
         //% help=sensors/gyro/compute-rotation-drift
-        //% block="compute **gyro** %this|rotation drift"
+        //% block="compute **gyro** $this|rotation drift"
         //% blockId=gyroComputeRotationDrift
         //% parts="gyroscope"
         //% blockNamespace=sensors
@@ -411,12 +424,12 @@ namespace sensors {
          * Computes the current sensor tilt drift when using rate measurements.
          */
         //% help=sensors/gyro/compute-tilt-drift
-        //% block="compute **gyro** %this|tilt drift"
+        //% block="compute **gyro** $this|tilt drift"
         //% blockId=gyroComputeTiltDrift
         //% parts="gyroscope"
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
-        //% weight=79 blockGap=8
+        //% weight=78
         //% group="Gyro Sensor"
         computeTiltDrift() {
             if (this._calibrating)
@@ -437,8 +450,9 @@ namespace sensors {
         //% blockNamespace=sensors
         //% this.fieldEditor="ports"
         //% degrees.defl=90
-        //% weight=98
+        //% weight=96
         //% group="Gyro Sensor"
+        //% deprecated=true
         pauseUntilRotated(degrees: number, timeOut?: number): void {
             let a = this.angle();
             const end = a + degrees;
@@ -446,9 +460,32 @@ namespace sensors {
             pauseUntil(() => (end - this.angle()) * direction <= 0, timeOut);
         }
 
+        /**
+         * Pauses the program until the gyro detected
+         * that the angle changed by the desired amount of degrees.
+         * @param degrees the degrees to turn
+         * @param axis the axis to rotation
+         * @param timeOut the max waiting time
+         */
+        //% help=sensors/gyro/pause-until-angle-rotated
+        //% block="pause until **gyro** $this|rotated $degrees=rotationPicker|degree $axis||at max waiting $timeOut"
+        //% blockId=pauseUntilAngleRotated
+        //% parts="gyroscope"
+        //% blockNamespace=sensors
+        //% this.fieldEditor="ports"
+        //% expandableArgumentMode="toogle"
+        //% degrees.defl=90
+        //% weight=96
+        //% group="Gyro Sensor"
+        pauseUntilAngleRotated(degrees: number, axis: GyroAxis, timeOut?: number): void {
+            let a = (axis == GyroAxis.Rotation ? this.rotationAngle() : this.tiltAngle());
+            const end = a + degrees;
+            const direction = (end - a) > 0 ? 1 : -1;
+            pauseUntil(() => (end - GyroAxis.Rotation ? this.rotationAngle() : this.tiltAngle()) * direction <= 0, timeOut);
+        }
+
         private computeRotationDriftNoCalibration() {
-            // clear rotation drift
-            this._rotationDrift = 0;
+            this._rotationDrift = 0; // clear rotation drift
             const n = 10;
             let d = 0;
             for (let i = 0; i < n; ++i) {
@@ -460,8 +497,7 @@ namespace sensors {
         }
 
         private computeTiltDriftNoCalibration() {
-            // clear tilt drift
-            this._tiltDrift = 0;
+            this._tiltDrift = 0; // clear tilt drift
             const n = 10;
             let d = 0;
             for (let i = 0; i < n; ++i) {

--- a/libs/gyro-sensor/gyro.ts
+++ b/libs/gyro-sensor/gyro.ts
@@ -84,9 +84,9 @@ namespace sensors {
             return Math.round(this._rotationAngle.value);
         }
 
-        rotationAngle(mode: GyroGetMethodValues = GyroGetMethodValues.RateEulerIntegrator): number {
-            if (mode == GyroGetMethodValues.RateEulerIntegrator) return this.angle();
-            else if (mode == GyroGetMethodValues.DeflVersion) {
+        rotationAngle(method: GyroGetMethodValues = GyroGetMethodValues.RateEulerIntegrator): number {
+            if (method == GyroGetMethodValues.RateEulerIntegrator) return this.angle();
+            else if (method == GyroGetMethodValues.DeflVersion) {
                 this.setMode(GyroSensorMode.Angle);
                 this.poke();
                 if (this._calibrating) {
@@ -97,15 +97,15 @@ namespace sensors {
             return 0;
         }
 
-        tiltAngle(mode: GyroGetMethodValues = GyroGetMethodValues.RateEulerIntegrator): number {
-            if (mode == GyroGetMethodValues.RateEulerIntegrator) {
+        tiltAngle(method: GyroGetMethodValues = GyroGetMethodValues.RateEulerIntegrator): number {
+            if (method == GyroGetMethodValues.RateEulerIntegrator) {
                 this.setMode(GyroSensorMode.TiltRate);
                 this.poke();
                 if (this._calibrating) {
                     pauseUntil(() => !this._calibrating, 2000);
                 }
                 return Math.round(this._tiltAngle.value);
-            } else if (mode == GyroGetMethodValues.DeflVersion) {
+            } else if (method == GyroGetMethodValues.DeflVersion) {
                 this.setMode(GyroSensorMode.TiltAngle);
                 this.poke();
                 if (this._calibrating) {

--- a/sim/state/gyro.ts
+++ b/sim/state/gyro.ts
@@ -1,8 +1,13 @@
 namespace pxsim {
     export const enum GyroSensorMode {
         None = -1,
-        Angle = 0,
-        Rate = 1,
+        Angle = 0, // Rotation angle
+        Rate = 1, // Rotational speed
+        GnA = 2, // Angle and rotational speed
+        Fas = 3, // Raw sensor value
+        Cal = 4, // Calibration
+        TiltRate = 5, // Tilt speed
+        TiltAngle = 6 // Tilt angle
     }
 
     export class GyroSensorNode extends UartSensorNode {

--- a/sim/visuals/board.ts
+++ b/sim/visuals/board.ts
@@ -265,7 +265,9 @@ namespace pxsim.visuals {
                 }
                 case NodeType.GyroSensor: {
                     const state = ev3board().getInputNodes()[port] as GyroSensorNode;
-                    view = new RotationSliderControl(this.element, this.defs, state, port);
+                    if (state.getMode() == GyroSensorMode.Rate || state.getMode() == GyroSensorMode.TiltRate) {
+                        view = new RotationSliderControl(this.element, this.defs, state, port);
+                    }
                     break;
                 }
                 case NodeType.NXTLightSensor: {


### PR DESCRIPTION
Using EulerIntegrator and the TiltRate mode, we obtain the value by analogy.
It is impossible to obtain the Rotation angle (angle()) and tiltAngle values at the same time due to the fact that the sensor switches mode.