### PR TITLE
Add editor tour

### DIFF
--- a/docs/tours/editor-tour.md
+++ b/docs/tours/editor-tour.md
@@ -1,0 +1,57 @@
+# Editor Tour
+* title: Editor tour
+* description: This tour shows the user around the LEGO MINDSTORMS EV3 editor, pointing out the toolbox, workspace, simulator, share button, and download button.
+
+## Welcome
+* title: Welcome!
+* description: New here? Take a tour of the editor!
+* highlight: nothing
+* location: center
+
+## EV3 Simulator
+* title: EV3 Simulator
+* description: See what your code looks like running on the simulator!
+* highlight: simulator
+* location: right
+
+## Toolbox
+* title: Toolbox
+* description: Drag out blocks of code from the Toolbox categories into the Workspace.
+* highlight: toolbox
+* location: right
+
+## Toolbox
+* title: Toolbox
+* description: Drag out snippets of code from the Toolbox categories into the Workspace.
+* highlight: monaco toolbox
+* location: right
+
+## Workspace
+* title: Workspace
+* description: Snap blocks of code together to build your program.
+* highlight: workspace
+* location: center
+
+## Workspace
+* title: Workspace
+* description: Write code to build your program.
+* highlight: monaco workspace
+* location: center
+
+## Share
+* title: Share
+* description: Create a link to your project to share with others.
+* highlight: share
+* location: below
+
+## Download
+* title: Download
+* description: Download your program onto your Arcade device.
+* highlight: download
+* location: above
+
+## Congrats
+* title: Congratulations!
+* description: You've completed the editor tour! 🤩🏆🤩 Happy coding!
+* highlight: everything
+* location: center

--- a/pxtarget.json
+++ b/pxtarget.json
@@ -213,7 +213,10 @@
         "githubEditor": true,
         "chooseLanguageRestrictionOnNewProject": true,
         "openProjectNewTab": true,
-        "python": true
+        "python": true,
+        "tours": {
+            "editor": "/tours/editor-tour"
+        }
     },
     "ignoreDocsErrors": true,
     "uploadDocs": true

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -206,6 +206,7 @@
 /*---------------------------
    Teaching Bubble
 ----------------------------*/
+
 @teachingBubbleBackgroundColor: @teal;
 @teachingBubbleTextColor: @white;
 @teachingBubbleStepsColor: @lightNougat;

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -202,3 +202,10 @@
 --------------------*/
 
 @extensionsHeaderBackground: @darkGrey;
+
+/*---------------------------
+   Teaching Bubble
+----------------------------*/
+@teachingBubbleBackgroundColor: @teal;
+@teachingBubbleTextColor: @white;
+@teachingBubbleStepsColor: @beige;

--- a/theme/site/globals/site.variables
+++ b/theme/site/globals/site.variables
@@ -208,4 +208,4 @@
 ----------------------------*/
 @teachingBubbleBackgroundColor: @teal;
 @teachingBubbleTextColor: @white;
-@teachingBubbleStepsColor: @beige;
+@teachingBubbleStepsColor: @lightNougat;


### PR DESCRIPTION
Added a tour of the editor as in microbit, arcade.
There is an error that when I launch a tour in Russian, instead of the editor, everything is filled with white, and this error appears in the console. And if you turn the editor into English, then everything works fine there. It turns out that this problem is for languages other than English.
![image](https://github.com/microsoft/pxt-ev3/assets/13646226/c48d2037-e237-4a8a-8598-18bd93d90e69)

I have a guess that the merge should happen first...